### PR TITLE
Support more types

### DIFF
--- a/src/DeclarationScope.ts
+++ b/src/DeclarationScope.ts
@@ -116,7 +116,7 @@ export class DeclarationScope {
     if (IGNORE_TYPENODES.has(node.kind)) {
       return;
     }
-    if (ts.isParenthesizedTypeNode(node) || ts.isTypeOperatorNode(node)) {
+    if (ts.isParenthesizedTypeNode(node) || ts.isTypeOperatorNode(node) || ts.isTypePredicateNode(node)) {
       return this.convertTypeNode(node.type);
     }
     if (ts.isArrayTypeNode(node)) {

--- a/src/DeclarationScope.ts
+++ b/src/DeclarationScope.ts
@@ -158,6 +158,10 @@ export class DeclarationScope {
       this.convertTypeNode(node.indexType);
       return;
     }
+    if (ts.isFunctionOrConstructorTypeNode(node)) {
+      this.convertParametersAndType(node);
+      return;
+    }
     // istanbul ignore else
     if (ts.isTypeReferenceNode(node)) {
       this.pushReference(this.convertEntityName(node.typeName));

--- a/src/__tests__/testcases/generics/expected.d.ts
+++ b/src/__tests__/testcases/generics/expected.d.ts
@@ -14,6 +14,18 @@ interface G {
 }
 interface H {
 }
+interface J {
+}
+interface K {
+}
+interface L {
+}
+interface M {
+}
+interface N {
+}
+interface O {
+}
 declare type Gen<T> = T;
 interface I<T = A> {
     a: T;
@@ -28,4 +40,6 @@ declare class Cl<T = E> {
     f: Gen<F>;
 }
 declare function fn<T = G>(g: T, h: Gen<H>): void;
-export { I, Ty, Cl, fn };
+declare type TyFn = <T = J>(j: T, k: Gen<K>) => L;
+declare type TyCtor = new <T = M>(m: T, n: Gen<N>) => O;
+export { I, Ty, Cl, fn, TyFn, TyCtor };

--- a/src/__tests__/testcases/generics/index.ts
+++ b/src/__tests__/testcases/generics/index.ts
@@ -6,6 +6,12 @@ interface E {}
 interface F {}
 interface G {}
 interface H {}
+interface J {}
+interface K {}
+interface L {}
+interface M {}
+interface N {}
+interface O {}
 
 type Gen<T> = T;
 
@@ -22,3 +28,5 @@ export class Cl<T = E> {
   f: Gen<F>;
 }
 export function fn<T = G>(g: T, h: Gen<H>) {}
+export type TyFn = <T = J>(j: T, k: Gen<K>) => L;
+export type TyCtor = new <T = M>(m: T, n: Gen<N>) => O;

--- a/src/__tests__/testcases/type-constructor/expected.d.ts
+++ b/src/__tests__/testcases/type-constructor/expected.d.ts
@@ -1,0 +1,8 @@
+interface A {
+}
+interface B {
+}
+interface C {
+}
+declare type Foo = new (a: A, b: B) => C;
+export { Foo };

--- a/src/__tests__/testcases/type-constructor/index.ts
+++ b/src/__tests__/testcases/type-constructor/index.ts
@@ -1,0 +1,5 @@
+interface A {}
+interface B {}
+interface C {}
+
+export type Foo = new (a: A, b: B) => C;

--- a/src/__tests__/testcases/type-function/expected.d.ts
+++ b/src/__tests__/testcases/type-function/expected.d.ts
@@ -1,0 +1,8 @@
+interface A {
+}
+interface B {
+}
+interface C {
+}
+declare type Foo = (a: A, b: B) => C;
+export { Foo };

--- a/src/__tests__/testcases/type-function/index.ts
+++ b/src/__tests__/testcases/type-function/index.ts
@@ -1,0 +1,5 @@
+interface A {}
+interface B {}
+interface C {}
+
+export type Foo = (a: A, b: B) => C;

--- a/src/__tests__/testcases/type-nodes/expected.d.ts
+++ b/src/__tests__/testcases/type-nodes/expected.d.ts
@@ -26,9 +26,12 @@ interface M {
 }
 interface N {
 }
+interface O {
+}
 declare function parenthesized(a: (A)): (B);
 declare function union(a: C | D): E | F;
 declare function intersection(a: G & H): I & J;
 declare function operator(a: keyof K): void;
 declare function arrayAndTuple(a: [L, M]): N[];
-export { parenthesized, union, intersection, operator, arrayAndTuple };
+declare function predicate(a: any): a is O;
+export { parenthesized, union, intersection, operator, arrayAndTuple, predicate };

--- a/src/__tests__/testcases/type-nodes/index.ts
+++ b/src/__tests__/testcases/type-nodes/index.ts
@@ -12,6 +12,7 @@ interface K {}
 interface L {}
 interface M {}
 interface N {}
+interface O {}
 
 // prettier-ignore
 export function parenthesized(a: (A)): (B) {
@@ -28,4 +29,7 @@ export function operator(a: keyof K) {
 }
 export function arrayAndTuple(a: [L, M]): N[] {
   return a;
+}
+export function predicate(a: any): a is O {
+  throw a;
 }


### PR DESCRIPTION
This adds support for:
* function types, e.g. `type Fn = (a: A) => B`
* constructor types, e.g. `type Ctor = new (a: A) => B`
* type predicates, e.g. `(a: any) => a is A`