### PR TITLE
Support imports without name

### DIFF
--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -210,8 +210,11 @@ export class Transformer {
 
   convertImportDeclaration(node: ts.ImportDeclaration) {
     const source = convertExpression(node.moduleSpecifier) as any;
+    if (!node.importClause) {
+      return
+    }
     // istanbul ignore if
-    if (!node.importClause || (!node.importClause.name && !node.importClause.namedBindings)) {
+    if (!node.importClause.name && !node.importClause.namedBindings) {
       console.log({ code: node.getFullText() });
       throw new Error(`ImportDeclaration should have imports`);
     }

--- a/src/__tests__/testcases/import-no-import-clause/bar.ts
+++ b/src/__tests__/testcases/import-no-import-clause/bar.ts
@@ -1,0 +1,1 @@
+export interface Bar {}

--- a/src/__tests__/testcases/import-no-import-clause/expected.d.ts
+++ b/src/__tests__/testcases/import-no-import-clause/expected.d.ts
@@ -1,0 +1,3 @@
+interface Foo {
+}
+export { Foo };

--- a/src/__tests__/testcases/import-no-import-clause/index.ts
+++ b/src/__tests__/testcases/import-no-import-clause/index.ts
@@ -1,0 +1,3 @@
+import "./bar";
+
+export interface Foo {}


### PR DESCRIPTION
I'd love to use this plugin (great work!) but I need to import some polyfills into my bundle (ex: `import 'core-js';`).

This PR adds support for this pattern.