### PR TITLE
Support even more types

### DIFF
--- a/src/DeclarationScope.ts
+++ b/src/DeclarationScope.ts
@@ -105,6 +105,9 @@ export class DeclarationScope {
     for (const heritage of node.heritageClauses || []) {
       for (const type of heritage.types) {
         this.pushReference(convertExpression(type.expression));
+        for (const arg of type.typeArguments || []) {
+          this.convertTypeNode(arg);
+        }
       }
     }
   }

--- a/src/DeclarationScope.ts
+++ b/src/DeclarationScope.ts
@@ -25,6 +25,7 @@ const IGNORE_TYPENODES = new Set([
   ts.SyntaxKind.SymbolKeyword,
   ts.SyntaxKind.NeverKeyword,
   ts.SyntaxKind.ThisKeyword,
+  ts.SyntaxKind.ThisType,
 ]);
 
 export class DeclarationScope {

--- a/src/__tests__/testcases/generics/expected.d.ts
+++ b/src/__tests__/testcases/generics/expected.d.ts
@@ -26,8 +26,10 @@ interface N {
 }
 interface O {
 }
+interface P {
+}
 declare type Gen<T> = T;
-interface I<T = A> {
+interface I1<T = A> {
     a: T;
     b: Gen<B>;
 }
@@ -42,4 +44,6 @@ declare class Cl<T = E> {
 declare function fn<T = G>(g: T, h: Gen<H>): void;
 declare type TyFn = <T = J>(j: T, k: Gen<K>) => L;
 declare type TyCtor = new <T = M>(m: T, n: Gen<N>) => O;
-export { I, Ty, Cl, fn, TyFn, TyCtor };
+interface I2 extends Gen<P> {
+}
+export { I1, Ty, Cl, fn, TyFn, TyCtor, I2 };

--- a/src/__tests__/testcases/generics/index.ts
+++ b/src/__tests__/testcases/generics/index.ts
@@ -12,10 +12,11 @@ interface L {}
 interface M {}
 interface N {}
 interface O {}
+interface P {}
 
 type Gen<T> = T;
 
-export interface I<T = A> {
+export interface I1<T = A> {
   a: T;
   b: Gen<B>;
 }
@@ -30,3 +31,5 @@ export class Cl<T = E> {
 export function fn<T = G>(g: T, h: Gen<H>) {}
 export type TyFn = <T = J>(j: T, k: Gen<K>) => L;
 export type TyCtor = new <T = M>(m: T, n: Gen<N>) => O;
+export interface I2 extends Gen<P> {
+}

--- a/src/__tests__/testcases/overrides/index.ts
+++ b/src/__tests__/testcases/overrides/index.ts
@@ -14,7 +14,7 @@ export default class Foo {
   method(c: C): D;
   method(e: E): F;
 
-  method(c: C | D): D | F {
-    throw c;
+  method(ce: C | E): D | F {
+    throw ce;
   }
 }

--- a/src/__tests__/testcases/shadowing/expected.d.ts
+++ b/src/__tests__/testcases/shadowing/expected.d.ts
@@ -15,4 +15,6 @@ declare type GenericType<K = any, L = K> = {
     k: K;
     l: L;
 };
-export { GenericInterface, GenericKlass, genericFunction, ConditionalInfer, Mapped, GenericType };
+interface GenericExtends<M = any, N = M> extends GenericInterface<M, N> {
+}
+export { GenericInterface, GenericKlass, genericFunction, ConditionalInfer, Mapped, GenericType, GenericExtends };

--- a/src/__tests__/testcases/shadowing/expected.d.ts
+++ b/src/__tests__/testcases/shadowing/expected.d.ts
@@ -11,4 +11,8 @@ declare type ConditionalInfer<G> = G extends Array<Array<infer H>> ? H : never;
 declare type Mapped<I> = {
     [J in keyof I]: I[J];
 };
-export { GenericInterface, GenericKlass, genericFunction, ConditionalInfer, Mapped };
+declare type GenericType<K = any, L = K> = {
+    k: K;
+    l: L;
+};
+export { GenericInterface, GenericKlass, genericFunction, ConditionalInfer, Mapped, GenericType };

--- a/src/__tests__/testcases/shadowing/exports.ts
+++ b/src/__tests__/testcases/shadowing/exports.ts
@@ -10,6 +10,8 @@ export interface I {}
 export interface J {}
 export interface K {}
 export interface L {}
+export interface M {}
+export interface N {}
 
 export class GenericKlass<A = any, B = A> {
   a: A;
@@ -33,3 +35,5 @@ export type GenericType<K = any, L = K> = {
   k: K;
   l: L;
 };
+
+export interface GenericExtends<M = any, N = M> extends GenericInterface<M, N> {}

--- a/src/__tests__/testcases/shadowing/index.ts
+++ b/src/__tests__/testcases/shadowing/index.ts
@@ -1,1 +1,8 @@
-export { GenericInterface, GenericKlass, genericFunction, ConditionalInfer, Mapped } from "./exports";
+export {
+  GenericInterface,
+  GenericKlass,
+  genericFunction,
+  ConditionalInfer,
+  Mapped,
+  GenericType
+} from "./exports";

--- a/src/__tests__/testcases/shadowing/index.ts
+++ b/src/__tests__/testcases/shadowing/index.ts
@@ -4,5 +4,6 @@ export {
   genericFunction,
   ConditionalInfer,
   Mapped,
-  GenericType
+  GenericType,
+  GenericExtends
 } from "./exports";

--- a/src/__tests__/testcases/type-this/expected.d.ts
+++ b/src/__tests__/testcases/type-this/expected.d.ts
@@ -1,0 +1,4 @@
+declare class Foo {
+    a: this;
+}
+export { Foo };

--- a/src/__tests__/testcases/type-this/expected.d.ts
+++ b/src/__tests__/testcases/type-this/expected.d.ts
@@ -1,4 +1,5 @@
 declare class Foo {
     a: this;
 }
-export { Foo };
+declare function thisType(this: Foo): void;
+export { thisType };

--- a/src/__tests__/testcases/type-this/index.ts
+++ b/src/__tests__/testcases/type-this/index.ts
@@ -1,0 +1,3 @@
+export class Foo {
+  a: this;
+}

--- a/src/__tests__/testcases/type-this/index.ts
+++ b/src/__tests__/testcases/type-this/index.ts
@@ -1,3 +1,7 @@
-export class Foo {
+class Foo {
   a: this;
+}
+
+export function thisType(this: Foo) {
+  return;
 }


### PR DESCRIPTION
### Support type parameters in an extends clause
```typescript
interface Foo<T> {
  foo: T;
}
interface Bar {}
interface FooBar extends Foo<Bar> {} // <<<
```
### Support `this` type node
```typescript
interface Foo {
  foo: string;
}
declare class FooBuilder {
  foo(foo: string): this; // <<<
  build(): Foo;
}
```
**Drive-by fix:** the "implementation" for the class method with overrides had an incorrect type. This doesn't affect the generated type definitions (since the implementation's signature is always removed), but I thought it's better to give it a more "realistic" type. 😛 