### PR TITLE
fix tsconfig lookup when projects directory contains dots

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,7 @@
 import * as ESTree from "estree";
 import * as ts from "typescript";
 import { Transformer } from "./Transformer";
+import fs from "fs";
 import path from "path";
 
 let SOURCEMAPPING_URL = "sourceMa";
@@ -41,7 +42,9 @@ const OPTIONS_OVERRIDES: ts.CompilerOptions = {
 const COMPILERCACHE = new Map<string, CacheEntry>();
 
 function createCompiler(options: CacheOptions) {
-  const file = path.basename(options.tsconfig);
+  const file = !fs.existsSync(options.tsconfig) || fs.lstatSync(options.tsconfig).isFile()
+    ? path.basename(options.tsconfig)
+    : undefined;
   const configFileName = ts.findConfigFile(
     options.tsconfig,
     ts.sys.fileExists,


### PR DESCRIPTION
The build is failing with the error `rollup-plugin-dts: Couldn't find tsconfig file` when a project directory contains dots.

## Steps to reproduce

1. Place `rollup.config.js` with the following configuration:
```
import { dts } from 'rollup-plugin-dts';

export default {
  input: 'src/index.ts',
  output: [
    {
      file: 'dist/index.d.ts',
      format: 'esm',
    },
  ],
  plugins: [ dts() ],
};
```

2. Rename your TypeScript project directory to contain at least one dot (like `my-library.js`).
3. Run `rollup -c rollup.config.js`.

## Expected behavior
Build succeeds.

## Actual behavior
Build fails with the error `rollup-plugin-dts: Couldn't find tsconfig file`.

## Problem description
Due to [this code](https://github.com/Swatinem/rollup-plugin-dts/blob/master/src/compiler.ts#L48), the plugin uses directory name as the `tsconfig` file name and then fails to find a file named `my-library.js`.

## Proposed solution
Perform a check whether `options.tsconfig` doesn't exist or is a regular file.