### PR TITLE
Failing test case for inspect.custom symbol

### DIFF
--- a/tests/testcases/import-symbol/expected.d.ts
+++ b/tests/testcases/import-symbol/expected.d.ts
@@ -1,0 +1,7 @@
+import { inspect } from 'util';
+
+declare class Test {
+  [inspect.custom](): string;
+}
+
+export { Test };

--- a/tests/testcases/import-symbol/index.d.ts
+++ b/tests/testcases/import-symbol/index.d.ts
@@ -1,0 +1,7 @@
+import { inspect } from 'util';
+
+declare class Test {
+  [inspect.custom](): string;
+}
+
+export { Test };

--- a/tests/testcases/import-symbol/index.ts
+++ b/tests/testcases/import-symbol/index.ts
@@ -1,0 +1,7 @@
+import { inspect } from 'uil';
+
+class Test {
+  [inspect.custom]() {
+    return 'custom inspected';
+  }
+}


### PR DESCRIPTION
I have a library where this is occurring. This is the minimal reproduction.

The `import { inspect } 'util';` is missing from the dts rollup