### PR TITLE
Support string literal class properties

### DIFF
--- a/src/DeclarationScope.ts
+++ b/src/DeclarationScope.ts
@@ -194,7 +194,7 @@ export class DeclarationScope {
     }
     const { expression } = node.name;
 
-    if (ts.isIdentifier(expression)) {
+    if (ts.isIdentifier(expression) || ts.isStringLiteral(expression)) {
       return this.pushReference(createIdentifier(expression));
     }
     if (ts.isPropertyAccessExpression(expression)) {


### PR DESCRIPTION
Before this change, this property in lit-element would fail when seen by rollup-plugin-dts:

```
export class LitElement extends UpdatingElement {
  protected static['finalized'] = true;
```

This is valid TS that fails with this plugin.