### PR TITLE
Add TS compiler options to plugin options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,11 @@ export interface Options {
    * configured via rollup.
    */
   respectExternal?: boolean;
+  compilerOptions?: ts.CompilerOptions;
 }
 
 const plugin: PluginImpl<Options> = (options = {}) => {
-  const { respectExternal = false } = options;
+  const { respectExternal = false, compilerOptions = {} } = options;
   // There exists one Program object per entry point,
   // except when all entry points are ".d.ts" modules.
   let programs: Array<ts.Program> = [];
@@ -165,7 +166,7 @@ const plugin: PluginImpl<Options> = (options = {}) => {
       importer = importer.split("\\").join("/");
 
       // resolve this via typescript
-      const { resolvedModule } = ts.nodeModuleNameResolver(source, importer, {}, ts.sys);
+      const { resolvedModule } = ts.nodeModuleNameResolver(source, importer, compilerOptions, ts.sys);
       if (!resolvedModule) {
         return;
       }


### PR DESCRIPTION
Hi, for my project I need set up `baseUrl` for TypeScript, so I added `compilerOptions` to handle it. 

I'm using absolute path, for example I have file `src/components/Button.tsx` and elsewhere I use import `import Button from 'components/Button'`.

If you find out it as valuable for you, plese look at the PR ;)
If I did something wrong, let me know, thank you (and for your work).