### PR TITLE
ExportAllDeclaration without exported should be null to avoid breaking rollup >= 2.9.x

### DIFF
--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -298,6 +298,7 @@ export class Transformer {
           {
             type: "ExportAllDeclaration",
             source,
+            exported: null
           },
           node,
         ),


### PR DESCRIPTION
when used rollup >= 2.9, (2.8 works well), TypeError cause

![image](https://user-images.githubusercontent.com/1667873/82273464-29097180-99b0-11ea-80b5-f886fd156357.png)


debug to locate here. 

i will report to rollup too.