### PR TITLE
fix: support of type aliases in namespaces

### DIFF
--- a/src/NamespaceFixer.ts
+++ b/src/NamespaceFixer.ts
@@ -66,6 +66,8 @@ export class NamespaceFixer {
         itemTypes[node.name!.getText()] = "function";
       } else if (ts.isInterfaceDeclaration(node)) {
         itemTypes[node.name.getText()] = "interface";
+      } else if (ts.isTypeAliasDeclaration(node)) {
+        itemTypes[node.name.getText()] = "type";
       } else if (ts.isModuleDeclaration(node) && ts.isIdentifier(node.name)) {
         itemTypes[node.name.getText()] = "namespace";
       } else if (ts.isEnumDeclaration(node)) {
@@ -131,7 +133,7 @@ export class NamespaceFixer {
       for (const { exportedName, localName } of ns.exports) {
         if (exportedName === localName) {
           const type = itemTypes[localName];
-          if (type === "interface") {
+          if (type === "interface" || type === "type") {
             // an interface is just a type
             code += `type ${ns.name}_${exportedName} = ${localName};\n`;
           } else if (type === "enum" || type === "class") {

--- a/tests/testcases/re-export-namespace-multiple/defs.d.ts
+++ b/tests/testcases/re-export-namespace-multiple/defs.d.ts
@@ -6,3 +6,4 @@ export declare enum D {
   B = 1,
 }
 export declare const E: string;
+export declare type F = string;

--- a/tests/testcases/re-export-namespace-multiple/expected.d.ts
+++ b/tests/testcases/re-export-namespace-multiple/expected.d.ts
@@ -6,6 +6,7 @@ declare enum D {
   B = 1,
 }
 declare const E: string;
+declare type F = string;
 type defs_d_A = A;
 declare const defs_d_b: typeof b;
 type defs_d_C = C;
@@ -13,6 +14,7 @@ declare const defs_d_C: typeof C;
 type defs_d_D = D;
 declare const defs_d_D: typeof D;
 declare const defs_d_E: typeof E;
+type defs_d_F = F;
 declare namespace defs_d {
   export {
     defs_d_A as A,
@@ -20,6 +22,7 @@ declare namespace defs_d {
     defs_d_C as C,
     defs_d_D as D,
     defs_d_E as E,
+    defs_d_F as F,
   };
 }
 declare namespace deep_d {

--- a/tests/testcases/re-export-namespace/expected.d.ts
+++ b/tests/testcases/re-export-namespace/expected.d.ts
@@ -1,15 +1,28 @@
 interface A {}
 declare function b(): void;
 declare class C {}
+declare enum D {
+  A = 0,
+  B = 1,
+}
+declare const E: string;
+declare type F = string;
 type namespace_d_A = A;
 declare const namespace_d_b: typeof b;
 type namespace_d_C = C;
 declare const namespace_d_C: typeof C;
+type namespace_d_D = D;
+declare const namespace_d_D: typeof D;
+declare const namespace_d_E: typeof E;
+type namespace_d_F = F;
 declare namespace namespace_d {
   export {
     namespace_d_A as A,
     namespace_d_b as b,
     namespace_d_C as C,
+    namespace_d_D as D,
+    namespace_d_E as E,
+    namespace_d_F as F,
   };
 }
 export { namespace_d as ns1, namespace_d as ns2 };

--- a/tests/testcases/re-export-namespace/namespace.d.ts
+++ b/tests/testcases/re-export-namespace/namespace.d.ts
@@ -1,3 +1,9 @@
 export interface A {}
 export declare function b(): void;
 export declare class C {}
+export declare enum D {
+  A = 0,
+  B = 1,
+}
+export declare const E: string;
+export declare type F = string;


### PR DESCRIPTION
namespace fixer treats interface as type and type as const. It should treat them same way.