### PR TITLE
Account for situation where itemTypes[localName] is undefined

### DIFF
--- a/src/transform/NamespaceFixer.ts
+++ b/src/transform/NamespaceFixer.ts
@@ -157,7 +157,7 @@ export class NamespaceFixer {
 
       for (const { exportedName, localName } of ns.exports) {
         if (exportedName === localName) {
-          const { type, generics } = itemTypes[localName]!;
+          const { type, generics } = itemTypes[localName] || {};
           if (type === "interface" || type === "type") {
             // an interface is just a type
             const typeParams = renderTypeParams(generics);


### PR DESCRIPTION
Sorry the PR doesn't come with a test case. I just came across a situation in this line:

```
const { type, generics } = itemTypes[localName]!
```

where  `itemTypes[localName]` is undefined. The destructuring statement throws and the build fails. I haven't been able to produce a repro as I'm time-constrained at the moment. However, this patch seems to fix the issue and it also matches the correct type signature by removing the postfix `!`.