### PR TITLE
fix: support keyword export names in namespace

### DIFF
--- a/src/transform/NamespaceFixer.ts
+++ b/src/transform/NamespaceFixer.ts
@@ -120,14 +120,18 @@ export class NamespaceFixer {
       }
       const exports: Array<Export> = [];
       for (const prop of obj.properties) {
-        if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name) || !ts.isToken(prop.name)) {
+        if (
+          !ts.isPropertyAssignment(prop) ||
+          !(ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) ||
+          (prop.name.text !== "__proto__" && !ts.isIdentifier(prop.initializer))
+        ) {
           throw new UnsupportedSyntaxError(prop, "Expected a property assignment");
         }
-        if (ts.isIdentifier(prop.name) && prop.name.text === "__proto__") {
+        if (prop.name.text === "__proto__") {
           continue;
         }
         exports.push({
-          exportedName: prop.name.getText(),
+          exportedName: prop.name.text,
           localName: prop.initializer.getText(),
         });
       }

--- a/src/transform/NamespaceFixer.ts
+++ b/src/transform/NamespaceFixer.ts
@@ -120,14 +120,10 @@ export class NamespaceFixer {
       }
       const exports: Array<Export> = [];
       for (const prop of obj.properties) {
-        if (
-          !ts.isPropertyAssignment(prop) ||
-          !ts.isIdentifier(prop.name) ||
-          (prop.name.text !== "__proto__" && !ts.isIdentifier(prop.initializer))
-        ) {
+        if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name) || !ts.isToken(prop.name)) {
           throw new UnsupportedSyntaxError(prop, "Expected a property assignment");
         }
-        if (prop.name.text === "__proto__") {
+        if (ts.isIdentifier(prop.name) && prop.name.text === "__proto__") {
           continue;
         }
         exports.push({

--- a/tests/testcases/namespace-keyword-exports/expected.d.ts
+++ b/tests/testcases/namespace-keyword-exports/expected.d.ts
@@ -1,0 +1,7 @@
+declare const _in = "foo";
+declare namespace foo_d {
+  export {
+    _in as in,
+  };
+}
+export { foo_d as foo };

--- a/tests/testcases/namespace-keyword-exports/foo.d.ts
+++ b/tests/testcases/namespace-keyword-exports/foo.d.ts
@@ -1,0 +1,3 @@
+declare const _in = "foo";
+
+export { _in as in };

--- a/tests/testcases/namespace-keyword-exports/index.d.ts
+++ b/tests/testcases/namespace-keyword-exports/index.d.ts
@@ -1,0 +1,1 @@
+export * as foo from "./foo";


### PR DESCRIPTION
Related issue: #149

As this may be a `.ts` input-file-only issue, I wasn't sure how to include tests for this.

If this is deemed unsupported, feel free to close this PR.