### PR TITLE
fix: *.d.ts always be writed  in root dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,12 @@ const plugin: PluginImpl<Options> = (options = {}) => {
         // an explicit object, which strips the file extension
         options.input = {};
         for (const filename of input) {
-          const name = path.basename(filename).replace(/((\.d)?\.(t|j)sx?)$/, "");
+          let name = filename.replace(/((\.d)?\.(t|j)sx?)$/, "");
+          if (path.isAbsolute(filename)) {
+            name = path.basename(name)
+          } else {
+            name = path.normalize(name)
+          }
           options.input[name] = filename;
         }
       }


### PR DESCRIPTION
I have dir tree:

```shell
├── a.ts
├── b-dir
    ├── b.ts
    └── c.ts
```

use tsup and make config as: 

```ts
import { defineConfig } from "tsup";

export default defineConfig({
  entryPoints: ["a.ts", "./b-dir/b.ts"],
  dts: true,
  clean: true,
});
```
to compile all ts file, and expect to get `dts` file.

```shell
pnpm tsup
```

I got `dist` dir, and the tree looks like this:

```shell
├── dist
    ├── a.d.ts
    ├── a.js
    ├── b-dir
    └── b.d.ts
```

File `b.d.ts` was written at dist  dir. But expected that `b.d.ts` should be `b-dir/`.
Just like:

```shell
├── dist
    ├── a.d.ts
    ├── a.js
    └── b-dir
        ├── b.d.ts
        └── b.js
```


Only the `Array` type `inputConfig.input` will Cause this situation.
When I make `inputConfig.input` be:
```js
{
  a: "a.ts", 
  "b-dir/b": "./b-dir/b.ts"
}
```
the tree:
```shell
├── dist
   ├── a.d.ts
    ├── a.js
    └── b-dir
        ├── b.d.ts
        └── b.js
```



