### PR TITLE
Support for reference path directives

### DIFF
--- a/tests/testcases/reference-path-remapping/expected.d.ts
+++ b/tests/testcases/reference-path-remapping/expected.d.ts
@@ -1,0 +1,9 @@
+/// <reference path="./sub/ns-api2.d.ts" />
+/// <reference path="./ns-api.d.ts" />
+declare class C2 {
+    public X: x2.I2;
+}
+declare class C1 {
+    public X: x1.I1;
+}
+export { C1, C2 };

--- a/tests/testcases/reference-path-remapping/index.d.ts
+++ b/tests/testcases/reference-path-remapping/index.d.ts
@@ -1,0 +1,7 @@
+/// <reference path="./ns-api.d.ts" />
+
+export * from "./sub/api2";
+
+export class C1 {
+    public X: x1.I1;
+}

--- a/tests/testcases/reference-path-remapping/ns-api.d.ts
+++ b/tests/testcases/reference-path-remapping/ns-api.d.ts
@@ -1,0 +1,3 @@
+declare namespace x1 {
+    export interface I1 { }
+}

--- a/tests/testcases/reference-path-remapping/sub/api2.d.ts
+++ b/tests/testcases/reference-path-remapping/sub/api2.d.ts
@@ -1,0 +1,5 @@
+/// <reference path="./ns-api2.d.ts" />
+
+export class C2 {
+    public X: x2.I2;
+}

--- a/tests/testcases/reference-path-remapping/sub/ns-api2.d.ts
+++ b/tests/testcases/reference-path-remapping/sub/ns-api2.d.ts
@@ -1,0 +1,3 @@
+declare namespace x2 {
+    export interface I2 { }
+}


### PR DESCRIPTION
PR to fix the [triple-slash reference path](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-), not correctly bundled in the output file.
For example:

`index.d.ts`:
```ts
/// <reference path="./lib-global-ns.d.ts" />
export * from "./sub/lib-es.ts";
```

`lib-es.ts`:
```ts
/// <reference path="./lib-global-ns-2.d.ts" />

// [...]
```
should result in a bundled file with all the references at the top, with correct relative paths:

```ts
/// <reference path="./lib-global-ns.d.ts" />
/// <reference path="./sub/lib-global-ns-2.d.ts" />

// [...]
```

The triple-slash reference path syntax can still be used in ES-module declarations files. For example, it can be used in mixed projects that are still using global namespaces. In that case, migrating a sub-section of the project should leave the structure of the reference paths untouched.

> Note: I'm sure how to get the target file path from the `renderChunk` function. During the UT the `options.file` seems to not be there, so I used the `chunk.facadeModuleId` in that case.

Thanks, L 