### PR TITLE
Reference remapping should not touch absolute path

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -105,13 +105,18 @@ export const transform: PluginImpl<TransformOptions> = () => {
           typeReferences.add(ref);
         }
         for (const ref of allFileReferences.get(fileName.split("\\").join("/")) || []) {
-          // Need absolute path of the target file here
-          const chunkFolder = (options.file && path.dirname(options.file)) || (chunk.facadeModuleId && path.dirname(chunk.facadeModuleId!)) || ".";
-          let targetRelPath = path.relative(chunkFolder, ref).split("\\").join("/");
-          if (targetRelPath[0] !== ".") {
-            targetRelPath = "./" + targetRelPath;
+          if (ref.startsWith('.')) {
+            // Need absolute path of the target file here
+            const absolutePathToOriginal = path.join(path.dirname(fileName), ref);
+            const chunkFolder = (options.file && path.dirname(options.file)) || (chunk.facadeModuleId && path.dirname(chunk.facadeModuleId!)) || ".";
+            let targetRelPath = path.relative(chunkFolder, absolutePathToOriginal).split("\\").join("/");
+            if (targetRelPath[0] !== ".") {
+              targetRelPath = "./" + targetRelPath;
+            }
+            fileReferences.add(targetRelPath);
+          } else {
+            fileReferences.add(ref);
           }
-          fileReferences.add(targetRelPath);
         }
       }
 

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -2,7 +2,7 @@ import MagicString from "magic-string";
 import ts from "typescript";
 import { matchesModifier } from "./astHelpers.js";
 import { UnsupportedSyntaxError } from "./errors.js";
-import * as path from "path";
+
 
 type Range = [start: number, end: number];
 
@@ -240,7 +240,8 @@ export function preProcess({ sourceFile }: PreProcessInput): PreProcessOutput {
   // and collect/remove all the fileReferenceDirectives
   const fileReferences = new Set<string>();
   for (const ref of sourceFile.referencedFiles) {
-    fileReferences.add(path.join(path.dirname(sourceFile.fileName), ref.fileName));
+    fileReferences.add(ref.fileName);
+
 
     const { line } = sourceFile.getLineAndCharacterOfPosition(ref.pos);
     const start = lineStarts[line]!;

--- a/tests/testcases/reference-path-remapping-should-not-touch-absolute-path/expected.d.ts
+++ b/tests/testcases/reference-path-remapping-should-not-touch-absolute-path/expected.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="/some/absolute/path" />
+interface Hello {}
+export { Hello };

--- a/tests/testcases/reference-path-remapping-should-not-touch-absolute-path/index.d.ts
+++ b/tests/testcases/reference-path-remapping-should-not-touch-absolute-path/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="/some/absolute/path" />
+
+export interface Hello {}


### PR DESCRIPTION
Hi 👋 
First of all thank you for the great package 🙃 , while using it I've noticed triple slash references are remapped to the main file, which is great.

However, while re-mapping references, IMO the remapping should handle _only_ relative paths, and leave as-is absolute paths.
Another option is to respect [noResolve](https://www.typescriptlang.org/tsconfig#noResolve) TS `compilerOptions` flag maybe?