### PR TITLE
fix: export both cjs and esm types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,14 @@
   "type": "module",
   "main": "./dist/rollup-plugin-dts.cjs",
   "exports": {
-    "types": "./dist/rollup-plugin-dts.d.ts",
+    "types": {
+      "import": "./dist/rollup-plugin-dts.d.mts",
+      "require": "./dist/rollup-plugin-dts.d.cts"
+    },
     "import": "./dist/rollup-plugin-dts.mjs",
     "require": "./dist/rollup-plugin-dts.cjs"
   },
-  "types": "./dist/rollup-plugin-dts.d.ts",
+  "types": "./dist/rollup-plugin-dts.d.cts",
   "sideEffects": false,
   "files": [
     "dist"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -15,7 +15,10 @@ const config: Array<RollupWatchOptions> = [
   },
   {
     input: "./.build/src/index.d.ts",
-    output: [{ file: pkg.types, format: "es" }],
+    output: [
+      { file: pkg.exports.types.import, format: "es" },
+      { file: pkg.exports.types.require, format: "commonjs", exports: "named" },
+    ],
     plugins: [dts()],
   },
 ];


### PR DESCRIPTION
Fixes #210

https://github.com/microsoft/TypeScript/issues/49299#issuecomment-1140421993#212 