### PR TITLE
feat!: support rollup v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "c8": "^7.12.0",
         "fs-extra": "^10.1.0",
         "rimraf": "^3.0.2",
-        "rollup": "2.79.1",
+        "rollup": "3.1.0",
         "typescript": "4.8.4"
       },
       "engines": {
@@ -34,7 +34,7 @@
         "@babel/code-frame": "^7.18.6"
       },
       "peerDependencies": {
-        "rollup": "^2.55",
+        "rollup": "^3.0.0",
         "typescript": "^4.1"
       }
     },
@@ -709,15 +709,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
+      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -1514,9 +1515,9 @@
       }
     },
     "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
+      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "c8": "^7.12.0",
     "fs-extra": "^10.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "2.79.1",
+    "rollup": "3.1.0",
     "typescript": "4.8.4"
   },
   "peerDependencies": {
-    "rollup": "^2.55",
+    "rollup": "^3.0.0",
     "typescript": "^4.1"
   },
   "optionalDependencies": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,5 @@
 import { RollupWatchOptions } from "rollup";
-import pkg from "./package.json";
+import pkg from "./package.json" assert { type: "json" };
 import dts from "./src/index.js";
 
 const external = ["module", "path", "typescript", "rollup", "@babel/code-frame", "magic-string"];

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -67,8 +67,8 @@ export const transform: PluginImpl<TransformOptions> = () => {
         exports: "named",
         compact: false,
         freeze: true,
-        interop: false,
-        namespaceToStringTag: false,
+        interop: 'esModule',
+        generatedCode: Object.assign({ symbols: false }, options.generatedCode),
         strict: false,
       };
     },


### PR DESCRIPTION
Resolves #226

- Update transform outputOptions for v3 compatibility 
- Update rollup peerDependency to `3.0.0` (options API is changed)
- Add json assertion to `package.json` import
