### PR TITLE
Cache `tsconfig.json` once resolved

### DIFF
--- a/tests/testcases/multiple-entries-multiple-tsconfigs/common.d.ts
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/common.d.ts
@@ -1,0 +1,3 @@
+export interface A {}
+export interface B {}
+export interface I {}

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/expected.d.ts
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/expected.d.ts
@@ -1,0 +1,11 @@
+// index.d.ts
+export { A, B, I } from './common.d-0ca74715.js';
+// entry-a.d.ts
+export { A } from './common.d-0ca74715.js';
+// entry-b.d.ts
+export { B } from './common.d-0ca74715.js';
+// common.d-0ca74715.d.ts
+interface A {}
+interface B {}
+interface I {}
+export { A, B, I };

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/meta.js
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/meta.js
@@ -1,0 +1,12 @@
+export default {
+  rollupOptions: {
+    input: [
+      "packages/packi/index.ts",
+      "packages/packi/src/entries/entry-a.ts",
+      "packages/packi/src/entries/entry-b.ts",
+    ],
+    output: {
+      entryFileNames: "[name].d.ts",
+    },
+  },
+};

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/index.ts
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/index.ts
@@ -1,0 +1,1 @@
+export * from "../../common";

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/src/entries/entry-a.ts
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/src/entries/entry-a.ts
@@ -1,0 +1,1 @@
+export { A } from "../../"; // the test should fail without `moduleResolution: node`

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/src/entries/entry-b.ts
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/src/entries/entry-b.ts
@@ -1,0 +1,1 @@
+export { B } from "../.."; // the test should fail without `moduleResolution: node`

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/tsconfig.json
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/packages/packi/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node" // the test should fail without this
+  },
+  "include": ["src", "index.ts"]
+}

--- a/tests/testcases/multiple-entries-multiple-tsconfigs/tsconfig.json
+++ b/tests/testcases/multiple-entries-multiple-tsconfigs/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "classic"
+  },
+  "include": ["does-not-exist"]
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -12,6 +12,16 @@ export function forEachFixture(fixtures: string, cb: (name: string, dir: string)
   }
 }
 
+function patchConsoleError() {
+  const originalConsoleError = console.error;
+  console.error = (message) => {
+    throw new Error(message);
+  };
+  return () => {
+    console.error = originalConsoleError;
+  };
+}
+
 export class Harness {
   tests = new Map<string, (bless: boolean) => any>();
 
@@ -35,6 +45,7 @@ export class Harness {
 
     let failures: Array<{ name: string; error: Error }> = [];
     for (const [name, fn] of this.tests.entries()) {
+      const restoreConsoleError = patchConsoleError();
       try {
         if (filter && !name.includes(filter)) {
           continue;
@@ -48,6 +59,8 @@ export class Harness {
         console.log();
         console.log((error as any).stack);
         console.log();
+      } finally {
+        restoreConsoleError();
       }
     }
 


### PR DESCRIPTION
Now caching `tsconfig.json` per directory. Related: https://github.com/Swatinem/rollup-plugin-dts/pull/238#issuecomment-1368398657

Other improvements:
- added tests for #238
- fail tests on `console.error`
- only resolve custom `compilerOptions` if needed i.e. if `tsconfig` option was provided
- logging for caching behaviour when `DTS_LOG_CACHE` env var is set

You can see tests failing with and without the last commit.

With this change, `getCompilerOptions` is only called a handful of times:

```
⚙️  Creating dts bundle...
getCompilerOptions()
[cache] miss /___/braid-design-system/packages/braid-design-system/src
[cache] tsconfig { <snip> }
[cache] /___/braid-design-system/packages/braid-design-system/src
[cache] up /___/braid-design-system/packages/braid-design-system
getCompilerOptions()
[cache] miss /___/braid-design-system/packages/braid-design-system/src/entries
[cache] tsconfig { <snip> }
[cache] /___/braid-design-system/packages/braid-design-system/src/entries
[cache] up /___/braid-design-system/packages/braid-design-system/src
[cache] has /___/braid-design-system/packages/braid-design-system/src
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries
getCompilerOptions()
[cache] miss /___/braid-design-system/packages/braid-design-system/src/entries/themes
[cache] tsconfig { <snip> }
[cache] /___/braid-design-system/packages/braid-design-system/src/entries/themes
[cache] up /___/braid-design-system/packages/braid-design-system/src/entries
[cache] has /___/braid-design-system/packages/braid-design-system/src/entries
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
getCompilerOptions()
[cache] HIT /___/braid-design-system/packages/braid-design-system/src/entries/themes
⚙️  Finished creating dts bundle
```
