### PR TITLE
Allow to use same resolve method as tsconfig (e.g. NodeNext)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ export default function rollupPluginDts(options: Options = {}) {
       }
 
       // resolve this via typescript
-      const { resolvedModule } = ts.nodeModuleNameResolver(source, importer, resolvedCompilerOptions, ts.sys);
+      const { resolvedModule } = ts.resolveModuleName(source, importer, resolvedCompilerOptions, ts.sys);
       if (!resolvedModule) {
         return;
       }

--- a/tests/testcases/inline-external-node-next-module/expected.d.ts
+++ b/tests/testcases/inline-external-node-next-module/expected.d.ts
@@ -1,0 +1,2 @@
+declare const foo = 'bar';
+export { foo };

--- a/tests/testcases/inline-external-node-next-module/index.d.ts
+++ b/tests/testcases/inline-external-node-next-module/index.d.ts
@@ -1,0 +1,1 @@
+export * from "package-a/file.js";

--- a/tests/testcases/inline-external-node-next-module/meta.js
+++ b/tests/testcases/inline-external-node-next-module/meta.js
@@ -1,11 +1,12 @@
 import ts from 'typescript';
 
 export default {
+  tsVersion: "4.7",
   options: {
     respectExternal: true,
     compilerOptions: {
-      module: ts.ModuleKind.NodeNext,
-      moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    }
+      module: ts.ModuleKind.Node16,
+      moduleResolution: ts.ModuleResolutionKind.Node16,
+    },
   },
 };

--- a/tests/testcases/inline-external-node-next-module/meta.js
+++ b/tests/testcases/inline-external-node-next-module/meta.js
@@ -1,0 +1,11 @@
+import ts from 'typescript';
+
+export default {
+  options: {
+    respectExternal: true,
+    compilerOptions: {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    }
+  },
+};

--- a/tests/testcases/inline-external-node-next-module/node_modules/package-a/package.json
+++ b/tests/testcases/inline-external-node-next-module/node_modules/package-a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "package-a",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./*": {
+      "types": "./types/*",
+      "default": "./files/*"
+    }
+  }
+}

--- a/tests/testcases/inline-external-node-next-module/node_modules/package-a/types/file.d.ts
+++ b/tests/testcases/inline-external-node-next-module/node_modules/package-a/types/file.d.ts
@@ -1,0 +1,1 @@
+export const foo = 'bar';


### PR DESCRIPTION
While trying to inline external dependencies, I saw that a TypeScript function was used that did not respect the moduleResolution of the config. It is changed to a similar functions that does respect the moduleResolution. There is also a test added that verifies that it works for NodeNext/Node16 for moduleResolution.