### PR TITLE
Add support for using `.d.cts` and `.d.mts` as inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export default function rollupPluginDts(options: Options = {}) {
         // an explicit object, which strips the file extension
         options.input = {};
         for (const filename of input) {
-          let name = filename.replace(/((\.d)?\.(t|j)sx?)$/, "");
+          let name = filename.replace(/((\.d)?\.(c|m)?(t|j)sx?)$/, "");
           if (path.isAbsolute(filename)) {
             name = path.basename(name);
           } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { Plugin } from "rollup";
 import ts from "typescript";
 import { Options, resolveDefaultOptions, ResolvedOptions } from "./options.js";
-import { createProgram, createPrograms, dts, formatHost, getCompilerOptions } from "./program.js";
+import { createProgram, createPrograms, dts, DTS_EXTENSIONS, formatHost, getCompilerOptions } from "./program.js";
 import { transform } from "./transform/index.js";
 
 export type { Options };
@@ -30,7 +30,7 @@ function getModule(
 ): ResolvedModule | null {
   // Create any `ts.SourceFile` objects on-demand for ".d.ts" modules,
   // but only when there are zero ".ts" entry points.
-  if (!programs.length && fileName.endsWith(dts)) {
+  if (!programs.length && DTS_EXTENSIONS.test(fileName)) {
     return { code };
   }
 
@@ -162,7 +162,7 @@ export default function rollupPluginDts(options: Options = {}) {
       };
 
       // if it's a .d.ts file, handle it as-is
-      if (id.endsWith(dts)) return handleDtsFile();
+      if (DTS_EXTENSIONS.test(id)) return handleDtsFile();
 
       // first attempt to treat .ts files as .d.ts files, and otherwise use the typescript compiler to generate the declarations
       return treatTsAsDts() ?? generateDtsFromTs();

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import ts from "typescript";
 
+export const DTS_EXTENSIONS = /\.d\.(c|m)?tsx?$/;
 export const dts = ".d.ts";
 
 export const formatHost: ts.FormatDiagnosticsHost = {
@@ -91,7 +92,7 @@ export function getCompilerOptions(
   }
   const { fileNames, options, errors } = configByPath.get(cacheKey)!;
 
-  dtsFiles = fileNames.filter((name) => name.endsWith(dts));
+  dtsFiles = fileNames.filter((name) => DTS_EXTENSIONS.test(name));
   if (errors.length) {
     console.error(ts.formatDiagnostics(errors, formatHost));
     return { dtsFiles, dirName, compilerOptions };
@@ -123,7 +124,7 @@ export function createPrograms(input: Array<string>, overrideOptions: ts.Compile
   let compilerOptions: ts.CompilerOptions = {};
 
   for (let main of input) {
-    if (main.endsWith(dts)) {
+    if (DTS_EXTENSIONS.test(main)) {
       continue;
     }
 

--- a/tests/testcases/using-dcts-files/expected.d.ts
+++ b/tests/testcases/using-dcts-files/expected.d.ts
@@ -1,0 +1,2 @@
+declare class MyClass {}
+export { MyClass };

--- a/tests/testcases/using-dcts-files/index.d.cts
+++ b/tests/testcases/using-dcts-files/index.d.cts
@@ -1,0 +1,2 @@
+declare class MyClass {}
+export { MyClass };

--- a/tests/testcases/using-dcts-files/meta.js
+++ b/tests/testcases/using-dcts-files/meta.js
@@ -1,0 +1,6 @@
+export default {
+  tsVersion: "4.8",
+  rollupOptions: {
+    input: "index.d.cts"
+  }
+};

--- a/tests/testcases/using-dmts-files/expected.d.ts
+++ b/tests/testcases/using-dmts-files/expected.d.ts
@@ -1,0 +1,2 @@
+declare class MyClass {}
+export { MyClass };

--- a/tests/testcases/using-dmts-files/index.d.mts
+++ b/tests/testcases/using-dmts-files/index.d.mts
@@ -1,0 +1,2 @@
+declare class MyClass {}
+export { MyClass };

--- a/tests/testcases/using-dmts-files/meta.js
+++ b/tests/testcases/using-dmts-files/meta.js
@@ -1,0 +1,6 @@
+export default {
+  tsVersion: "4.8",
+  rollupOptions: {
+    input: "index.d.mts"
+  }
+};


### PR DESCRIPTION
I've introduced the `DTS_EXTENSIONS` regex, similar to the existing `TS_EXTENSIONS` one, and used it in places that were simply checking if the file name ends with the `.d.ts`. Thanks to that `.d.cts` and `.d.mts` files can be used as inputs for the plugin.

Closes #252.