### PR TITLE
add support for import aliases

### DIFF
--- a/src/transform/DeclarationScope.ts
+++ b/src/transform/DeclarationScope.ts
@@ -346,7 +346,8 @@ export class DeclarationScope {
         ts.isClassDeclaration(stmt) ||
         ts.isInterfaceDeclaration(stmt) ||
         ts.isTypeAliasDeclaration(stmt) ||
-        ts.isModuleDeclaration(stmt)
+        ts.isModuleDeclaration(stmt) ||
+        ts.isImportEqualsDeclaration(stmt)
       ) {
         if (stmt.name && ts.isIdentifier(stmt.name)) {
           this.pushTypeVariable(stmt.name);
@@ -407,6 +408,10 @@ export class DeclarationScope {
         // noop
         continue;
       }
+      if (ts.isImportEqualsDeclaration(stmt)) {
+        // noop
+        continue;
+      }
       if (ts.isExportDeclaration(stmt)) {
         if (stmt.exportClause) {
           if (ts.isNamespaceExport(stmt.exportClause)) {
@@ -417,9 +422,9 @@ export class DeclarationScope {
             this.pushIdentifierReference(id);
           }
         }
-      } else {
-        throw new UnsupportedSyntaxError(stmt, `namespace child (walking) not supported yet`);
+        continue;
       }
+      throw new Error(`unsupported statement type ${ts.SyntaxKind[stmt.kind]}`);
     }
 
     this.popScope();

--- a/src/transform/DeclarationScope.ts
+++ b/src/transform/DeclarationScope.ts
@@ -325,11 +325,11 @@ export class DeclarationScope {
     }
   }
 
-  convertNamespace(node: ts.ModuleDeclaration, relaxedModuleBlock = false) {
+  convertNamespace(node: ts.ModuleDeclaration) {
     this.pushScope();
 
-    if (relaxedModuleBlock && node.body && ts.isModuleDeclaration(node.body)) {
-      this.convertNamespace(node.body, true);
+    if (node.body && ts.isModuleDeclaration(node.body)) {
+      this.convertNamespace(node.body);
       return;
     }
     if (!node.body || !ts.isModuleBlock(node.body)) {
@@ -400,7 +400,7 @@ export class DeclarationScope {
         continue;
       }
       if (ts.isModuleDeclaration(stmt)) {
-        this.convertNamespace(stmt, relaxedModuleBlock);
+        this.convertNamespace(stmt);
         continue;
       }
       if (ts.isEnumDeclaration(stmt)) {

--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -1,7 +1,7 @@
 import * as ESTree from "estree";
 import ts from "typescript";
-import { convertExpression, createIdentifier, createProgram, withStartEnd } from "./astHelpers.js";
 import { DeclarationScope } from "./DeclarationScope.js";
+import { convertExpression, createIdentifier, createProgram, withStartEnd } from "./astHelpers.js";
 import { UnsupportedSyntaxError } from "./errors.js";
 
 type ESTreeImports = ESTree.ImportDeclaration["specifiers"];
@@ -127,7 +127,7 @@ class Transformer {
 
     if (isGlobalAugmentation || !ts.isIdentifier(node.name)) {
       const scope = this.createDeclaration(node);
-      scope.convertNamespace(node, true);
+      scope.convertNamespace(node);
       return;
     }
 

--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -248,8 +248,6 @@ class Transformer {
     }
   }
 
-  convertNamespaceAlias() {}
-
   convertImportDeclaration(node: ts.ImportDeclaration | ts.ImportEqualsDeclaration) {
     if (ts.isImportEqualsDeclaration(node)) {
       // assume its like `import default`

--- a/tests/testcases/import-aliases/expected.d.ts
+++ b/tests/testcases/import-aliases/expected.d.ts
@@ -1,0 +1,8 @@
+declare namespace Foo {
+  export type Bar = "hello, world";
+}
+declare namespace Bar {
+  export import fb = Foo.Bar;
+}
+export import bfb = Bar.fb;
+export { Bar, Foo };

--- a/tests/testcases/import-aliases/index.d.ts
+++ b/tests/testcases/import-aliases/index.d.ts
@@ -1,0 +1,9 @@
+export namespace Foo {
+  export type Bar = "hello, world";
+}
+
+export namespace Bar {
+  export import fb = Foo.Bar;
+}
+
+export import bfb = Bar.fb;

--- a/tests/testcases/nested-namespaces/expected.d.ts
+++ b/tests/testcases/nested-namespaces/expected.d.ts
@@ -1,0 +1,4 @@
+declare namespace Deeply.Nested.Namespace {
+  export const Hello = "World";
+}
+export { Deeply };

--- a/tests/testcases/nested-namespaces/index.d.ts
+++ b/tests/testcases/nested-namespaces/index.d.ts
@@ -1,0 +1,3 @@
+export namespace Deeply.Nested.Namespace {
+  export const Hello = "World";
+}


### PR DESCRIPTION
i've been blocked with this plugin due to the lack of support for import aliases (i.e. `export import something = Some.Namespace.Member`) in a project at work. I'm not sure if this is the correct solution, as I will be honest I am not actually sure why my changes in Transformer cause it to work. i think I am at the limits of my understanding of this codebase. removing either the `.createDeclaration` or the `.pushStatement` causes the import aliases to be dropped from the output, but I don't really understand why.

nevertheless, this does fix support and I have added test cases to prove it. i also fixed nested namespace support while I was at it as some of my own personal tests involved a nested namespace.

also closes #246, although that was not my original purpose :P

I think it might be a step in the right direction for some of the ppl over in #162 but only a couple of their cases seem to be related to import aliases. the majority seem to genuinely be related to hoisting children of namespaces

please advise if you have any better ideas for how to support this! all existing tests pass as well as the new cases I added in order to confirm support.