### PR TITLE
fix: export both cjs and esm types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
   },
   "type": "module",
   "main": "./dist/rollup-plugin-dts.cjs",
+  "types": "./dist/rollup-plugin-dts.d.cts",
   "exports": {
-    "types": "./dist/rollup-plugin-dts.d.ts",
     "import": "./dist/rollup-plugin-dts.mjs",
     "require": "./dist/rollup-plugin-dts.cjs"
   },
-  "types": "./dist/rollup-plugin-dts.d.ts",
   "sideEffects": false,
   "files": [
     "dist"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -15,7 +15,10 @@ const config: Array<RollupWatchOptions> = [
   },
   {
     input: "./.build/src/index.d.ts",
-    output: [{ file: pkg.types, format: "es" }],
+    output: [
+      { file: pkg.exports.import.replace(/\.mjs$/, ".d.mts") },
+      { file: pkg.exports.require.replace(/\.cjs$/, ".d.cts") },
+    ],
     plugins: [dts()],
   },
 ];


### PR DESCRIPTION
close https://github.com/Swatinem/rollup-plugin-dts/issues/210