### PR TITLE
docs: add clarity to the .default import pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ const config = [
 
 export default config;
 ```
+**NOTE** In some implementations of the rollup config file, you may receive the error: `[!] TypeError: dts is not a function`[^1] [^2]. In which case, use the following implementation:
+```js
+import dts from "rollup-plugin-dts";
+
+const config = [
+  // …
+  {
+    input: "./my-input/index.d.ts",
+    output: [{ file: "dist/my-library.d.ts", format: "es" }],
+    plugins: [dts.default()],
+  },
+];
+
+export default config;
+```
 
 And then instruct typescript where to find your definitions inside your `package.json`:
 
@@ -82,3 +97,7 @@ about some of these projects and their tradeoffs.
 
 The code is licensed under the copyleft **LGPL-3.0**. I have no intention to
 license this under any non-copyleft license.
+
+
+[^1]: [StackOverflow thread](https://stackoverflow.com/questions/74255565/rollup-typescript-error-dts-is-not-a-function/74304876#74304876) of issue
+[^2]: [Github issue](https://github.com/Swatinem/rollup-plugin-dts/issues/247)


### PR DESCRIPTION
## Describing the problem
If you import the plugin as directed in the docs you may encounter a console error like:
```js
import dts from "rollup-plugin-dts";

const config = [
  // …
  {
    input: "./my-input/index.d.ts",
    output: [{ file: "dist/my-library.d.ts", format: "es" }],
    plugins: [dts()],
  },
];

export default config;
```

```
[!] TypeError: dts is not a function
```

And you will be returned this if you log `dts` to the console:
```
{ default: [Function: plugin] }
```
This is a recorded issue in #247.

## Describing the solution
This PR modifies the usage portion of the README.md file to include documentation on how to handle this error by using the package with `dts.default()`. This PR also includes sources to the issue within the README.md.

## Describing changes to the package
This PR only changes the documentation in the README.md and does not affect implementation.