### PR TITLE
chore(deps): lower the node requirements to >=16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [16, 18, 20]
         os: [ubuntu-latest, windows-latest]
 
     name: Node ${{ matrix.node }} on ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Swatinem/rollup-plugin-dts#readme",
   "engines": {
-    "node": ">=v18.17.1"
+    "node": ">=16"
   },
   "type": "module",
   "main": "./dist/rollup-plugin-dts.cjs",


### PR DESCRIPTION
lower the `node` requirements to `>=16`,reduce install fail caused by the `engine-strict = true` configuration item in `.npmrc`. #282 