### PR TITLE
fix: `typeof this` usage in classes should not alias to `typeof this$1`

### DIFF
--- a/src/transform/DeclarationScope.ts
+++ b/src/transform/DeclarationScope.ts
@@ -92,6 +92,8 @@ export class DeclarationScope {
         }
       }
     }
+    // `this` is a reserved keyword that retrains meaning in certain Type-only contexts, including classes
+    if (name === "this") return;
     const { ident, expr } = createReference(id);
 
     this.declaration.params.push(expr);

--- a/tests/testcases/type-typeof-this/expected.d.ts
+++ b/tests/testcases/type-typeof-this/expected.d.ts
@@ -1,0 +1,4 @@
+declare class NumberSchema {
+  min: () => typeof this;
+}
+export { NumberSchema };

--- a/tests/testcases/type-typeof-this/index.d.ts
+++ b/tests/testcases/type-typeof-this/index.d.ts
@@ -1,0 +1,3 @@
+export declare class NumberSchema {
+  min: () => typeof this;
+}


### PR DESCRIPTION
Closes #279