### PR TITLE
Fix fallback path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ function getModule(
     // we know this exists b/c of the .filter above, so this non-null assertion is safe
     const source = existingProgram.getSourceFile(fileName)!;
     return {
-      code: source.getFullText(),
+      code: source?.getFullText(),
       source,
       program: existingProgram,
     };
@@ -51,7 +51,7 @@ function getModule(
     // we created hte program from this fileName, so the source file must exist :P
     const source = newProgram.getSourceFile(fileName)!;
     return {
-      code: source.getFullText(),
+      code: source?.getFullText(),
       source,
       program: newProgram,
     };


### PR DESCRIPTION
The `generateDtsFromTs` path expects cases where `!module.source` but since #249 `getModule` does not actually return it as it fails trying to use it for gathering `code`.