### PR TITLE
Add rollup v4 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^20.8.0",
         "@types/react": "^18.2.24",
         "c8": "^8.0.1",
-        "rollup": "3.29.4",
+        "rollup": "^4.0.1",
         "typescript": "5.2.2"
       },
       "engines": {
@@ -32,7 +32,7 @@
         "@babel/code-frame": "^7.22.13"
       },
       "peerDependencies": {
-        "rollup": "^3.29.4",
+        "rollup": "^3.29.4 || ^4",
         "typescript": "^4.5 || ^5.0"
       }
     },
@@ -116,6 +116,162 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.0.1.tgz",
+      "integrity": "sha512-u6xSfKQXP6NlQYr1+3b+rYEG2YsczVC46ZQjdkBtP+IKqRNT6w6ivTv4ywoxN/rMpBirrru73nvPF7F/gyTkJw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.0.1.tgz",
+      "integrity": "sha512-cV7bMb68ipnlgxNjV2fvJRLeIHaEnJr6MrYo6+Re4rp5+B3iJMeOvd/ICjneWcutKzEiFtiyK55FSyu4A1juMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.0.1.tgz",
+      "integrity": "sha512-I+AvpO2lt+ZpXcTIG1JU99fD1kNUqk7ppKBMcBRHRXlE+e+QV1Ewpq7yjD346dNg/O8Tq5qzM9hoUAziM3jVMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.0.1.tgz",
+      "integrity": "sha512-qe4+FV6OhtOrn3gOCfzXN3BpxwJsrQg8SgnbdrtAFQyG9jZm1kTYREc1TvKSpFLGZyC0dtBS21JTS4e1+RXiCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.0.1.tgz",
+      "integrity": "sha512-UIvgXnd1Y5r9JiYzd1O8+rmyX+xfzNI04wHU7xhkJOKPTopia2NPV/vmyLokgjVffwY9kjfB8a9ZC+1ApGR9GA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.0.1.tgz",
+      "integrity": "sha512-1AKiocQGspfLBrn71FDMpDOIjLJjQhvepwHV3/o9lO5XVSoN/hXH1OeRj6dSkcwozltUTRipQZJ6ku7mX0ZIkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.0.1.tgz",
+      "integrity": "sha512-/2oPDPDCby4mY2P5xaw6d34Q52sb4X/IgUsoYTkDttapxtnMdQTdD55GhCJhydbozXkn4EC8jbnlQieCB+eE+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.0.1.tgz",
+      "integrity": "sha512-8ow9ljQUBOdLKIKWFBVfdR9O80+TjkbrIo65YhC24Zxnpld342vZdgF3BRKgRECfKIq5nZY4A75JIhr9KaJiEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.0.1.tgz",
+      "integrity": "sha512-EBbduwEBd4x3JprMc1CBZUeagX5EwwCMUx2mN7BNkoWbHrN3e0RDss1T7X9m2gmXsEl5fdPxTTgUo9t3h2V7IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.0.1.tgz",
+      "integrity": "sha512-AJ0NKL2X/eMq2ED7APz1zDrf70sqIJPdtD1zqgGnqKN0ipn8iDQCiNF9xRolx7ImH6CF+jA1n3/VzgD4a8eVNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.0.1.tgz",
+      "integrity": "sha512-WLHoLsYM5MFbChbLZFyCg0PwqncENl/UKECSYmlSW8X/LZ1KWhBBVrPcI491+mW9BrxdlR0yi/cGGSrC9dr/ig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.0.1.tgz",
+      "integrity": "sha512-ysfyyP59n4VUdn3GTfDHg8szzf4Gg01OY6n5DT3hC8jVyyq2pesj8Mq+3yiIGsnnA9uKO6kyWdOGGAy1m6ttAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@types/babel__code-frame": {
       "version": "7.0.4",
@@ -684,18 +840,30 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.0.1.tgz",
+      "integrity": "sha512-D/1zxbxgSHPPwZS10ybZElOF9ohQc2yop6wG4vlAy8jQaKvjrPu3gjlGVe0+dI7I9NKkm9CtZAzomnaPie/05A==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.0.1",
+        "@rollup/rollup-android-arm64": "4.0.1",
+        "@rollup/rollup-darwin-arm64": "4.0.1",
+        "@rollup/rollup-darwin-x64": "4.0.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.0.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.0.1",
+        "@rollup/rollup-linux-arm64-musl": "4.0.1",
+        "@rollup/rollup-linux-x64-gnu": "4.0.1",
+        "@rollup/rollup-linux-x64-musl": "4.0.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.0.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.0.1",
+        "@rollup/rollup-win32-x64-msvc": "4.0.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -1014,6 +1182,90 @@
           "dev": true
         }
       }
+    },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.0.1.tgz",
+      "integrity": "sha512-u6xSfKQXP6NlQYr1+3b+rYEG2YsczVC46ZQjdkBtP+IKqRNT6w6ivTv4ywoxN/rMpBirrru73nvPF7F/gyTkJw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.0.1.tgz",
+      "integrity": "sha512-cV7bMb68ipnlgxNjV2fvJRLeIHaEnJr6MrYo6+Re4rp5+B3iJMeOvd/ICjneWcutKzEiFtiyK55FSyu4A1juMg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.0.1.tgz",
+      "integrity": "sha512-I+AvpO2lt+ZpXcTIG1JU99fD1kNUqk7ppKBMcBRHRXlE+e+QV1Ewpq7yjD346dNg/O8Tq5qzM9hoUAziM3jVMw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.0.1.tgz",
+      "integrity": "sha512-qe4+FV6OhtOrn3gOCfzXN3BpxwJsrQg8SgnbdrtAFQyG9jZm1kTYREc1TvKSpFLGZyC0dtBS21JTS4e1+RXiCg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.0.1.tgz",
+      "integrity": "sha512-UIvgXnd1Y5r9JiYzd1O8+rmyX+xfzNI04wHU7xhkJOKPTopia2NPV/vmyLokgjVffwY9kjfB8a9ZC+1ApGR9GA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.0.1.tgz",
+      "integrity": "sha512-1AKiocQGspfLBrn71FDMpDOIjLJjQhvepwHV3/o9lO5XVSoN/hXH1OeRj6dSkcwozltUTRipQZJ6ku7mX0ZIkQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.0.1.tgz",
+      "integrity": "sha512-/2oPDPDCby4mY2P5xaw6d34Q52sb4X/IgUsoYTkDttapxtnMdQTdD55GhCJhydbozXkn4EC8jbnlQieCB+eE+g==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.0.1.tgz",
+      "integrity": "sha512-8ow9ljQUBOdLKIKWFBVfdR9O80+TjkbrIo65YhC24Zxnpld342vZdgF3BRKgRECfKIq5nZY4A75JIhr9KaJiEA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.0.1.tgz",
+      "integrity": "sha512-EBbduwEBd4x3JprMc1CBZUeagX5EwwCMUx2mN7BNkoWbHrN3e0RDss1T7X9m2gmXsEl5fdPxTTgUo9t3h2V7IQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.0.1.tgz",
+      "integrity": "sha512-AJ0NKL2X/eMq2ED7APz1zDrf70sqIJPdtD1zqgGnqKN0ipn8iDQCiNF9xRolx7ImH6CF+jA1n3/VzgD4a8eVNA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.0.1.tgz",
+      "integrity": "sha512-WLHoLsYM5MFbChbLZFyCg0PwqncENl/UKECSYmlSW8X/LZ1KWhBBVrPcI491+mW9BrxdlR0yi/cGGSrC9dr/ig==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.0.1.tgz",
+      "integrity": "sha512-ysfyyP59n4VUdn3GTfDHg8szzf4Gg01OY6n5DT3hC8jVyyq2pesj8Mq+3yiIGsnnA9uKO6kyWdOGGAy1m6ttAg==",
+      "dev": true,
+      "optional": true
     },
     "@types/babel__code-frame": {
       "version": "7.0.4",
@@ -1460,11 +1712,23 @@
       }
     },
     "rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.0.1.tgz",
+      "integrity": "sha512-D/1zxbxgSHPPwZS10ybZElOF9ohQc2yop6wG4vlAy8jQaKvjrPu3gjlGVe0+dI7I9NKkm9CtZAzomnaPie/05A==",
       "dev": true,
       "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.0.1",
+        "@rollup/rollup-android-arm64": "4.0.1",
+        "@rollup/rollup-darwin-arm64": "4.0.1",
+        "@rollup/rollup-darwin-x64": "4.0.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.0.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.0.1",
+        "@rollup/rollup-linux-arm64-musl": "4.0.1",
+        "@rollup/rollup-linux-x64-gnu": "4.0.1",
+        "@rollup/rollup-linux-x64-musl": "4.0.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.0.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.0.1",
+        "@rollup/rollup-win32-x64-msvc": "4.0.1",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "@types/node": "^20.8.0",
     "@types/react": "^18.2.24",
     "c8": "^8.0.1",
-    "rollup": "3.29.4",
+    "rollup": "^4.0.1",
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "rollup": "^3.29.4",
+    "rollup": "^3.29.4 || ^4",
     "typescript": "^4.5 || ^5.0"
   },
   "optionalDependencies": {

--- a/tests/testcases/multiple-entries-cjs/expected.d.ts
+++ b/tests/testcases/multiple-entries-cjs/expected.d.ts
@@ -1,8 +1,8 @@
 // main-a.d.cts
-export { A } from './main-b.d-e5346d3a.js';
+export { A } from './main-b.d-FG8lOMpq.js';
 // main-b.d.cts
-export { B } from './main-b.d-e5346d3a.js';
-// main-b.d-e5346d3a.d.ts
+export { B } from './main-b.d-FG8lOMpq.js';
+// main-b.d-FG8lOMpq.d.ts
 interface A {}
 interface B {}
 export type { A, B };

--- a/tests/testcases/multiple-entries-mjs/expected.d.ts
+++ b/tests/testcases/multiple-entries-mjs/expected.d.ts
@@ -1,8 +1,8 @@
 // main-a.d.mts
-export { A } from './main-b.d-e5346d3a.mjs';
+export { A } from './main-b.d-FG8lOMpq.mjs';
 // main-b.d.mts
-export { B } from './main-b.d-e5346d3a.mjs';
-// main-b.d-e5346d3a.d.mts
+export { B } from './main-b.d-FG8lOMpq.mjs';
+// main-b.d-FG8lOMpq.d.mts
 interface A {}
 interface B {}
 export type { A, B };

--- a/tests/testcases/multiple-entries/expected.d.ts
+++ b/tests/testcases/multiple-entries/expected.d.ts
@@ -1,8 +1,8 @@
 // >main-a<.d.ts
-export { A } from './main-b.d-e5346d3a.js';
+export { A } from './main-b.d-FG8lOMpq.js';
 // >main-b<.d.ts
-export { B } from './main-b.d-e5346d3a.js';
-// main-b.d-e5346d3a.d.ts
+export { B } from './main-b.d-FG8lOMpq.js';
+// main-b.d-FG8lOMpq.d.ts
 interface A {}
 interface B {}
 export type { A, B };

--- a/tests/testcases/using-mts-cts-files/expected.d.ts
+++ b/tests/testcases/using-mts-cts-files/expected.d.ts
@@ -1,8 +1,8 @@
 // mts.d.ts
-export { A } from './main-b-0fcfb715.js';
+export { A } from './main-b-QmL8JJ4D.js';
 // cts.d.ts
-export { B } from './main-b-0fcfb715.js';
-// main-b-0fcfb715.d.ts
+export { B } from './main-b-QmL8JJ4D.js';
+// main-b-QmL8JJ4D.d.ts
 interface A {
 }
 interface B {

--- a/tests/testcases/using-ts-files/expected.d.ts
+++ b/tests/testcases/using-ts-files/expected.d.ts
@@ -1,8 +1,8 @@
 // a.d.ts
-export { A } from './main-b-0fcfb715.js';
+export { A } from './main-b-QmL8JJ4D.js';
 // b.d.ts
-export { B } from './main-b-0fcfb715.js';
-// main-b-0fcfb715.d.ts
+export { B } from './main-b-QmL8JJ4D.js';
+// main-b-QmL8JJ4D.d.ts
 interface A {
 }
 interface B {


### PR DESCRIPTION
This pull request adds rollup v4 to the allowed peer dependencies range.

@Swatinem it would be really great if you could merge this PR to allow your long-time users to continue using this awesome plugin with the latest version of rollup.

Close #293 