### PR TITLE
chore(copyright): update license to LGPL-3.0-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types"
   ],
   "author": "Arpad Borsos <arpad.borsos@googlemail.com>",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-only",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Swatinem/rollup-plugin-dts.git"


### PR DESCRIPTION
In our application we use strict dependency license checking.

rollup-plugin-dts has **LGPL-3.0** in license field, but according to [license docs](https://spdx.org/licenses/LGPL-3.0.html), the identifier "**LGPL-3.0**" has been deprecated; **LGPL-3.0-only** is the preferred identifier to indicate only version 3.0 of the LGPL.

Can we change license field value in pacakge.json to **LGPL-3.0-only**?