### PR TITLE
fix: don't break transform when there is no space between unnamed default exported function and generic parameter bracket

### DIFF
--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -189,7 +189,8 @@ export function preProcess({ sourceFile }: PreProcessInput): PreProcessOutput {
         nextToken.kind >= ts.SyntaxKind.FirstPunctuation && nextToken.kind <= ts.SyntaxKind.LastPunctuation;
 
       if (isPunctuation) {
-        code.appendLeft(nextToken.getStart(), defaultExport);
+        const addSpace = code.slice(token.getEnd(), nextToken.getStart()) != " ";
+        code.appendLeft(nextToken.getStart(), `${addSpace ? " " : ""}${defaultExport}`);
       } else {
         code.appendRight(token.getEnd(), ` ${defaultExport}`);
       }

--- a/tests/testcases/unnamed-default-export-without-space/expected.d.ts
+++ b/tests/testcases/unnamed-default-export-without-space/expected.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @description @TODO
+ */
+declare function export_default<T extends object>(
+  object: T,
+  initializationObject: {
+    [x in keyof T]: () => Promise<T[x]>;
+  },
+): Promise<void>;
+export { export_default as default };

--- a/tests/testcases/unnamed-default-export-without-space/index.d.ts
+++ b/tests/testcases/unnamed-default-export-without-space/index.d.ts
@@ -1,0 +1,9 @@
+/**
+ * @description @TODO
+ */
+export default function<T extends object>(
+  object: T,
+  initializationObject: {
+    [x in keyof T]: () => Promise<T[x]>;
+  },
+): Promise<void>;


### PR DESCRIPTION
Currently it throws errors like this:

```ts
[!] (plugin dts) Error: Syntax not yet supported

  62 | }
  63 |
> 64 | declare functionexport_default<T extends Request = Request>(
     | ^^^^^^^
  65 |  options?: IOptions<T>
  66 | ): Polka<T>;
  67 |
node_modules/.pnpm/polka@1.0.0-next.25/node_modules/polka/index.d.mts
    at Transformer.convertStatement (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1301:19)
    at new Transformer (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1230:18)
    at convert (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1221:25)
    at Object.transform (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1668:31)
    at handleDtsFile (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1805:54)
    at Object.transform (file:///Users/divyansh/vitepress/node_modules/.pnpm/rollup-plugin-dts@6.1.0_rollup@4.17.2_typescript@5.4.5/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1840:24)
    at /Users/divyansh/vitepress/node_modules/.pnpm/rollup@4.17.2/node_modules/rollup/dist/shared/rollup.js:989:40
```

Input:

```ts
export default function<T extends Request = Request>(
	options?: IOptions<T>
): Polka<T>;
```

Please see added test for easier repro.