### PR TITLE
fix: force emit types even when there're errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ const plugin: PluginImpl<Options> = (options = {}) => {
           },
           undefined, // cancellationToken
           true, // emitOnlyDtsFiles
+          undefined, // customTransformers
+          // @ts-ignore This is a private API for workers, should be safe to use as TypeScript Playground has used it for a long time.
+          true, // forceDtsEmit
         );
         if (emitSkipped) {
           const errors = diagnostics.filter((diag) => diag.category === ts.DiagnosticCategory.Error);

--- a/tests/testcases/using-ts-files/common.ts
+++ b/tests/testcases/using-ts-files/common.ts
@@ -1,3 +1,6 @@
 export interface A {}
 export interface B {}
 export interface unused {}
+// The following code triggers `Unused '@ts-expect-error' directive` error,
+// but it doesn't actually prevent the DTS from being emitted.
+// @ts-expect-error


### PR DESCRIPTION
The dts plugin runs TypeScript to generate .d.ts files for .ts inputs. This often _just works_. However in some cases it still fails to fetch types from deep dependencies. I used to [turn off all strict type-checking options](https://github.com/hyrious/dts/commit/5cda654e7786767942824f44bfa13e7bdcf7e510#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to get rid of these errors, but today I found a special case which doesn't work in any option settings:

```ts
// @ts-expect-error
expectString(null)

function expectString(a: string) {}
```

1. If `strictNullChecks: false`, the code above raises `Unused '@ts-expect-error' directive`.
2. If I remove the directive, the code above cannot pass my projects type checking.

I only want to generate and bundle types and don't want to handle any type errors. So today I found that the TypeScript Playground actually _can_ emit types even when there're errors in the code. After digging a while I found the hidden option to force emitting types.