### PR TITLE
fix: Preserve type members of namespace in re-exported module

### DIFF
--- a/src/transform/NamespaceFixer.ts
+++ b/src/transform/NamespaceFixer.ts
@@ -197,6 +197,9 @@ export class NamespaceFixer {
             const typeParams = renderTypeParams(generics);
             code += `type ${ns.name}_${exportedName}${typeParams.in} = ${localName}${typeParams.out};\n`;
             code += `declare const ${ns.name}_${exportedName}: typeof ${localName};\n`;
+          } else if (type === "namespace") {
+            // namespaces may contain both types and values
+            code += `import ${ns.name}_${exportedName} = ${localName};\n`;
           } else {
             // functions and vars are just values
             code += `declare const ${ns.name}_${exportedName}: typeof ${localName};\n`;

--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -250,6 +250,12 @@ class Transformer {
 
   convertImportDeclaration(node: ts.ImportDeclaration | ts.ImportEqualsDeclaration) {
     if (ts.isImportEqualsDeclaration(node)) {
+      if (ts.isEntityName(node.moduleReference)) {
+        const scope = this.createDeclaration(node, node.name);
+        scope.pushReference(scope.convertEntityName(node.moduleReference));
+        return;
+      }
+
       // assume its like `import default`
       if (!ts.isExternalModuleReference(node.moduleReference)) {
         throw new UnsupportedSyntaxError(node, "ImportEquals should have a literal source.");

--- a/tests/testcases/re-export-namespace-inner/expected.d.ts
+++ b/tests/testcases/re-export-namespace-inner/expected.d.ts
@@ -1,0 +1,9 @@
+declare namespace inner {
+  type Ty = number;
+  const num: number;
+}
+import mod_d_inner = inner;
+declare namespace mod_d {
+  export { mod_d_inner as inner };
+}
+export { mod_d as outer };

--- a/tests/testcases/re-export-namespace-inner/index.d.ts
+++ b/tests/testcases/re-export-namespace-inner/index.d.ts
@@ -1,0 +1,2 @@
+import * as outer from "./mod";
+export { outer };

--- a/tests/testcases/re-export-namespace-inner/mod.d.ts
+++ b/tests/testcases/re-export-namespace-inner/mod.d.ts
@@ -1,0 +1,5 @@
+declare namespace inner {
+  type Ty = number;
+  const num: number;
+}
+export { inner };


### PR DESCRIPTION
Previously we would generate `declare const …: typeof …` which declares an object with the same value members but none of the type members.

- Fixes #322.