### PR TITLE
fix: Return Source Map Differences to Rollup

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -134,10 +134,9 @@ export const transform = () => {
         code += "\nexport { };";
       }
 
-      const typeOnlyFixer = new TypeOnlyFixer(chunk.fileName, code);
-      code = typeOnlyFixer.fix();
+      const typeOnlyFixer = new TypeOnlyFixer(chunk.fileName, code, !!options.sourcemap);
 
-      return { code, map: { mappings: "" } };
+      return typeOnlyFixer.fix();
     },
   } satisfies Plugin;
 };


### PR DESCRIPTION
This commit enables users to remap declaration source maps by passing back the computed difference.

To utilize the original DTS source map, users may need additional plugins like `rollup-sourcemap`.