### PR TITLE
fix: disable the type-only transform

### DIFF
--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -1,9 +1,8 @@
 import type * as ESTree from "estree";
 import ts from "typescript";
-import { convertExpression, convertTypeOnlyHintStatement, createIdentifier, createProgram, withStartEnd } from "./astHelpers.js";
+import { convertExpression, createIdentifier, createProgram, withStartEnd } from "./astHelpers.js";
 import { DeclarationScope } from "./DeclarationScope.js";
 import { UnsupportedSyntaxError } from "./errors.js";
-import { parseTypeOnlyName } from "./TypeOnlyFixer.js";
 
 type ESTreeImports = ESTree.ImportDeclaration["specifiers"];
 
@@ -166,10 +165,17 @@ class Transformer {
   }
 
   convertTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
-    if(parseTypeOnlyName(node.name.text).isTypeOnly) {
-      this.pushStatement(convertTypeOnlyHintStatement(node))
-      return
-    }
+    /**
+     * TODO: type-only import/export fixer.
+     * Temporarily disable the type-only import/export transformation,
+     * because the current implementation is unsafe.
+     * 
+     * Issue: https://github.com/Swatinem/rollup-plugin-dts/issues/340
+     */
+    // if(parseTypeOnlyName(node.name.text).isTypeOnly) {
+    //   this.pushStatement(convertTypeOnlyHintStatement(node))
+    //   return
+    // }
     
     const scope = this.createDeclaration(node, node.name);
 

--- a/src/transform/TypeOnlyFixer.ts
+++ b/src/transform/TypeOnlyFixer.ts
@@ -195,22 +195,28 @@ export class TypeOnlyFixer {
         this.DEBUG && console.log(`${node.name.getFullText()} is a type`);
         this.types.add(alias);
 
-        if (ts.isTypeReferenceNode(node.type) && ts.isIdentifier(node.type.typeName)) {
-          const reference = node.type.typeName.text;
-          const aliasHint = parseTypeOnlyName(alias);
+        /**
+         * Temporarily disable the type-only import/export transformation,
+         * because the current implementation is unsafe.
+         * 
+         * Issue: https://github.com/Swatinem/rollup-plugin-dts/issues/340
+         */
+        // if (ts.isTypeReferenceNode(node.type) && ts.isIdentifier(node.type.typeName)) {
+        //   const reference = node.type.typeName.text;
+        //   const aliasHint = parseTypeOnlyName(alias);
 
-          if(aliasHint.isTypeOnly) {
-            this.DEBUG && console.log(`${reference} is a type (from type-only hint)`);
-            this.types.add(reference);
-            this.typeHints.set(reference, (this.typeHints.get(reference) || 0) + 1);
-            if(aliasHint.isReExport) {
-              const reExportName = alias.split(TYPE_ONLY_RE_EXPORT)[0]!
-              this.DEBUG && console.log(`${reExportName} is a type (from type-only re-export hint)`);
-              this.reExportTypeHints.set(reExportName, (this.reExportTypeHints.get(reExportName) || 0) + 1);
-            }
-            this.code.remove(node.getStart(), node.getEnd());
-          }
-        }
+        //   if(aliasHint.isTypeOnly) {
+        //     this.DEBUG && console.log(`${reference} is a type (from type-only hint)`);
+        //     this.types.add(reference);
+        //     this.typeHints.set(reference, (this.typeHints.get(reference) || 0) + 1);
+        //     if(aliasHint.isReExport) {
+        //       const reExportName = alias.split(TYPE_ONLY_RE_EXPORT)[0]!
+        //       this.DEBUG && console.log(`${reExportName} is a type (from type-only re-export hint)`);
+        //       this.reExportTypeHints.set(reExportName, (this.reExportTypeHints.get(reExportName) || 0) + 1);
+        //     }
+        //     this.code.remove(node.getStart(), node.getEnd());
+        //   }
+        // }
         continue;
       }
 

--- a/src/transform/TypeOnlyFixer.ts
+++ b/src/transform/TypeOnlyFixer.ts
@@ -196,6 +196,7 @@ export class TypeOnlyFixer {
         this.types.add(alias);
 
         /**
+         * TODO: type-only import/export fixer.
          * Temporarily disable the type-only import/export transformation,
          * because the current implementation is unsafe.
          * 

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -195,6 +195,7 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     checkInlineImport(node);
 
     /**
+     * TODO: type-only import/export fixer.
      * Temporarily disable the type-only import/export transformation,
      * because the current implementation is unsafe.
      * 

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -194,8 +194,14 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     // recursively check inline imports
     checkInlineImport(node);
 
-    transformTypeOnlyImport(node);
-    transformTypeOnlyExport(node);
+    /**
+     * Temporarily disable the type-only import/export transformation,
+     * because the current implementation is unsafe.
+     * 
+     * Issue: https://github.com/Swatinem/rollup-plugin-dts/issues/340
+     */
+    // transformTypeOnlyImport(node);
+    // transformTypeOnlyExport(node);
 
     if (!matchesModifier(node, ts.ModifierFlags.ExportDefault)) {
       continue;
@@ -305,6 +311,7 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     fileReferences,
   };
 
+  // @ts-expect-error temporary disabled
   function transformTypeOnlyImport(node: ts.Node) {
     if (!ts.isImportDeclaration(node) || !node.importClause) {
       return;
@@ -351,6 +358,7 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     }
   }
 
+  // @ts-expect-error temporary disabled
   function transformTypeOnlyExport(node: ts.Node) {
     if(!ts.isExportDeclaration(node)) {
       return;

--- a/tests/testcases/custom-tsconfig/expected.d.ts
+++ b/tests/testcases/custom-tsconfig/expected.d.ts
@@ -1,3 +1,2 @@
 interface Foo {}
-//@ts-expect-error
 export type { Foo };

--- a/tests/testcases/type-only-import-export/meta.js
+++ b/tests/testcases/type-only-import-export/meta.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  rollupOptions: {},
+  /**
+   * TODO: Until we found a safe way to handle the type-only import/export, 
+   * we skip this test.
+   */
+  skip: true,
+};


### PR DESCRIPTION
resolves #340

This PR temporarily disables the type-only transform until we find a safer way to handle this issue.

Previously closed issue #311 needs to be reopen, sorry for the inconvenience...