### PR TITLE
fix: rewrite names of module declarations with relative paths

### DIFF
--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -1,0 +1,56 @@
+import ts from "typescript";
+import MagicString from "magic-string";
+import { parse } from "../helpers.js";
+
+export class RelativeModuleDeclarationFixer {
+  private sourcemap: boolean;
+  private DEBUG: boolean;
+  private relativeModuleDeclarations: ts.ModuleDeclaration[];
+  private source: ts.SourceFile;
+  private code: MagicString;
+  private name: string;
+
+  constructor(fileName: string, code: MagicString, sourcemap: boolean, name?: string) {
+    this.sourcemap = sourcemap;
+    this.DEBUG = !!process.env.DTS_EXPORTS_FIXER_DEBUG;
+    this.relativeModuleDeclarations = [];
+    this.source = parse(fileName, code.toString());
+    this.code = code;
+    this.name = name || "./index";
+  }
+
+  fix() {
+    this.analyze(this.source.statements);
+
+    for (const node of this.relativeModuleDeclarations) {
+      const start = node.getStart();
+      const end = node.getEnd();
+
+      const quote =
+        node.name.kind === ts.SyntaxKind.StringLiteral && "singleQuote" in node.name && node.name.singleQuote
+          ? "'"
+          : '"';
+
+      const code = `declare module ${quote}${this.name}${quote} ${node.body!.getText()}`;
+
+      this.code.overwrite(start, end, code);
+    }
+
+    return {
+      code: this.code.toString(),
+      map: this.relativeModuleDeclarations.length && this.sourcemap ? this.code.generateMap() : null,
+    };
+  }
+
+  analyze(nodes: ts.NodeArray<ts.Statement>) {
+    for (const node of nodes) {
+      if (ts.isModuleDeclaration(node) && node.body && ts.isModuleBlock(node.body) && /^\.\.?\//.test(node.name.text)) {
+        if (this.DEBUG) {
+          console.log(`Found relative module declaration: ${node.name.text} in ${this.source.fileName}`);
+        }
+
+        this.relativeModuleDeclarations.push(node);
+      }
+    }
+  }
+}

--- a/src/transform/TypeOnlyFixer.ts
+++ b/src/transform/TypeOnlyFixer.ts
@@ -22,7 +22,7 @@ export class TypeOnlyFixer {
   private importNodes: ImportDeclarationWithClause[] = [];
   private exportNodes: ExportDeclarationWithClause[] = [];
 
-  constructor(fileName: string, rawCode: string, private sourcemap: boolean) {
+  constructor(fileName: string, rawCode: string) {
     this.rawCode = rawCode;
     this.source = parse(fileName, rawCode);
     this.code = new MagicString(rawCode);
@@ -45,8 +45,7 @@ export class TypeOnlyFixer {
 
     return this.types.size
       ? {
-          code: this.code.toString(),
-          map: this.sourcemap ? this.code.generateMap() : null,
+          magicCode: this.code,
         }
       : {
           code: this.rawCode,

--- a/tests/testcases/declare-relative-module/expected.d.ts
+++ b/tests/testcases/declare-relative-module/expected.d.ts
@@ -1,0 +1,9 @@
+interface Foo {
+  someProp: boolean;
+}
+declare module "./index" {
+  interface Foo {
+    anotherProp: string;
+  }
+}
+export type { Foo };

--- a/tests/testcases/declare-relative-module/extend-foo.d.ts
+++ b/tests/testcases/declare-relative-module/extend-foo.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare module "./foo" {
+  interface Foo {
+    anotherProp: string;
+  }
+}

--- a/tests/testcases/declare-relative-module/foo.d.ts
+++ b/tests/testcases/declare-relative-module/foo.d.ts
@@ -1,0 +1,3 @@
+export interface Foo {
+  someProp: boolean;
+}

--- a/tests/testcases/declare-relative-module/index.d.ts
+++ b/tests/testcases/declare-relative-module/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./foo";
+export * from "./extend-foo";


### PR DESCRIPTION
This fixes #345.

## Problem

Module declarations are just copied into the output file verbatim. This breaks for module declarations with relative paths. For example:

```typescript
declare module "../config" {
  interface Config {
    foo: number;
  }
}
```

This will just simply be copied, although the relative module path will no longer exist after running this plugin.

This breaks cross-module type extensions with relative paths, i.e. extending the pre-existing `Config` interface from `../config.ts` in the case above.

## Solution

To solve this, a new fixer is introduced that rewrites all relative module declarations in such a way, that they reference the output file itself, i.e. if the output file were called `index.d.ts`, the above would be rewritten as:

```typescript
declare module "./index" {
  interface Config {
    foo: number;
  }
}
```

Now, the pre-existing interface taken from `../config.ts` will be properly extended again.
