### PR TITLE
refactor: remove unused value reference tracking from DeclarationScope, Transformer, TypeOnlyFixer, and index

### DIFF
--- a/src/transform/DeclarationScope.ts
+++ b/src/transform/DeclarationScope.ts
@@ -39,7 +39,6 @@ export class DeclarationScope {
   declaration: ESTree.FunctionDeclaration;
   iife?: ESTree.ExpressionStatement;
   private returnExpr: ESTree.ArrayExpression;
-  private valueReferences: Set<string> = new Set();
 
   constructor({ id, range }: DeclarationScopeOptions) {
     if (id) {
@@ -71,14 +70,6 @@ export class DeclarationScope {
   pushTypeVariable(id: ts.Identifier) {
     const name = id.getText();
     this.scopes[this.scopes.length - 1]?.add(name);
-  }
-
-  markAsValue(name: string) {
-    this.valueReferences.add(name);
-  }
-
-  getValueReferences(): Set<string> {
-    return this.valueReferences;
   }
 
   pushReference(id: ESTree.Expression) {
@@ -313,13 +304,6 @@ export class DeclarationScope {
     if (ts.isTypeQueryNode(node)) {
       const reference = this.convertEntityName(node.exprName);
       this.pushReference(reference);
-
-      if (reference.type === "Identifier") {
-        this.markAsValue(reference.name);
-      } else if (reference.type === "MemberExpression" && reference.object.type === "Identifier") {
-        this.markAsValue(reference.object.name);
-      }
-
       this.convertTypeArguments(node);
 
       return;

--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -12,7 +12,6 @@ interface ConvertInput {
 
 interface ConvertOutput {
   ast: ESTree.Program;
-  valueReferences: Set<string>;
 }
 
 export function convert({ sourceFile }: ConvertInput): ConvertOutput {
@@ -22,7 +21,6 @@ export function convert({ sourceFile }: ConvertInput): ConvertOutput {
 
 class Transformer {
   ast: ESTree.Program;
-  allTypeReferences: Set<string> = new Set();
 
   declarations = new Map<string, DeclarationScope>();
 
@@ -31,18 +29,11 @@ class Transformer {
     for (const stmt of sourceFile.statements) {
       this.convertStatement(stmt);
     }
-
-    for (const scope of this.declarations.values()) {
-      for (const valueRef of scope.getValueReferences()) {
-        this.allTypeReferences.add(valueRef);
-      }
-    }
   }
 
   transform(): ConvertOutput {
     return {
       ast: this.ast,
-      valueReferences: this.allTypeReferences,
     };
   }
 

--- a/src/transform/TypeOnlyFixer.ts
+++ b/src/transform/TypeOnlyFixer.ts
@@ -17,7 +17,6 @@ export class TypeOnlyFixer {
   private values: Set<string> = new Set();
   private typeHints: Map<string, number> = new Map();
   private reExportTypeHints: Map<string, number> = new Map();
-  private typeofValueReferences: Set<string> = new Set();
 
   private importNodes: ImportDeclarationWithClause[] = [];
   private exportNodes: ExportDeclarationWithClause[] = [];
@@ -28,9 +27,6 @@ export class TypeOnlyFixer {
     this.code = new MagicString(rawCode);
   }
 
-  setValueReferences(valueReferences: Set<string>) {
-    this.typeofValueReferences = valueReferences;
-  }
 
   fix() {
     this.analyze(this.source.statements);
@@ -278,9 +274,6 @@ export class TypeOnlyFixer {
   }
 
   private isTypeOnly(name: string) {
-    if(this.typeofValueReferences.has(name)) {
-      return false;
-    }
     return this.typeHints.has(name)
       || (this.types.has(name) && !this.values.has(name));
   }

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -29,7 +29,6 @@ import MagicString from "magic-string";
 export const transform = () => {
   const allTypeReferences = new Map<string, Set<string>>();
   const allFileReferences = new Map<string, Set<string>>();
-  const allValueReferences = new Map<string, Set<string>>();
 
   return {
     name: "dts-transform",
@@ -91,8 +90,6 @@ export const transform = () => {
       sourceFile = parse(fileName, code);
       const converted = convert({ sourceFile });
 
-      allValueReferences.set(sourceFile.fileName, converted.valueReferences);
-
       if (process.env.DTS_DUMP_AST) {
         console.log(fileName);
         console.log(code);
@@ -108,13 +105,10 @@ export const transform = () => {
 
       const typeReferences = new Set<string>();
       const fileReferences = new Set<string>();
-      const valueReferences = new Set<string>();
+
       for (const fileName of Object.keys(chunk.modules)) {
         for (const ref of allTypeReferences.get(fileName.split("\\").join("/")) || []) {
           typeReferences.add(ref);
-        }
-        for (const ref of allValueReferences.get(fileName.split("\\").join("/")) || []) {
-          valueReferences.add(ref);
         }
         for (const ref of allFileReferences.get(fileName.split("\\").join("/")) || []) {
           if (ref.startsWith(".")) {
@@ -144,7 +138,6 @@ export const transform = () => {
       }
 
       const typeOnlyFixer = new TypeOnlyFixer(chunk.fileName, code);
-      typeOnlyFixer.setValueReferences(typeReferences);
 
       const typesFixed = typeOnlyFixer.fix();
 


### PR DESCRIPTION
To solve the issue in #348  , we actually only needed `this.convertTypeArguments(node)`, but it included excessive behavior like typeof value processing.

This PR removes those unnecessary parts. While the existing code wouldn't cause problems, I think it would be better to keep modifications as concise as possible when maintaining this project.