### PR TITLE
feat(transform): add support for child imports and nesting in namespaces

### DIFF
--- a/tests/testcases/namespace-child-import/expected.d.ts
+++ b/tests/testcases/namespace-child-import/expected.d.ts
@@ -1,0 +1,8 @@
+interface AnInterface {
+  prop: number;
+}
+declare namespace Bar {
+  type Baz = AnInterface;
+  export type Qux = Baz;
+}
+export { Bar };

--- a/tests/testcases/namespace-child-import/foo.d.ts
+++ b/tests/testcases/namespace-child-import/foo.d.ts
@@ -1,0 +1,3 @@
+export interface AnInterface {
+  prop: number;
+}

--- a/tests/testcases/namespace-child-import/index.d.ts
+++ b/tests/testcases/namespace-child-import/index.d.ts
@@ -1,0 +1,6 @@
+import * as Foo from "./foo";
+
+export namespace Bar {
+  import Baz = Foo.AnInterface;
+  export type Qux = Baz;
+}

--- a/tests/testcases/namespace-child-import/meta.js
+++ b/tests/testcases/namespace-child-import/meta.js
@@ -1,0 +1,6 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/namespace-function-alias/expected.d.ts
+++ b/tests/testcases/namespace-function-alias/expected.d.ts
@@ -1,0 +1,9 @@
+declare function myFunc(arg: string): void;
+// Augment the function with a namespace
+declare namespace myFunc {
+  // Create an alias to the outer function for re-exporting as default
+  import _default = myFunc;
+  export { _default as default };
+  export const SOME_PROP = 123;
+}
+export { myFunc };

--- a/tests/testcases/namespace-function-alias/index.d.ts
+++ b/tests/testcases/namespace-function-alias/index.d.ts
@@ -1,0 +1,10 @@
+export declare function myFunc(arg: string): void;
+
+// Augment the function with a namespace
+export declare namespace myFunc {
+  // Create an alias to the outer function for re-exporting as default
+  import _default = myFunc;
+  export { _default as default };
+
+  export const SOME_PROP = 123;
+}

--- a/tests/testcases/namespace-function-alias/meta.js
+++ b/tests/testcases/namespace-function-alias/meta.js
@@ -1,0 +1,6 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/namespace-nested-export/expected.d.ts
+++ b/tests/testcases/namespace-nested-export/expected.d.ts
@@ -1,0 +1,10 @@
+interface External {
+  id: string;
+}
+declare namespace Container {
+  namespace Nested {
+    type Local = External;
+    export type FinalType = Local;
+  }
+}
+export { Container };

--- a/tests/testcases/namespace-nested-export/index.d.ts
+++ b/tests/testcases/namespace-nested-export/index.d.ts
@@ -1,0 +1,8 @@
+import * as Types from './types';
+
+export namespace Container {
+  export namespace Nested {
+    import Local = Types.External;
+    export type FinalType = Local;
+  }
+}

--- a/tests/testcases/namespace-nested-export/meta.js
+++ b/tests/testcases/namespace-nested-export/meta.js
@@ -1,0 +1,6 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/namespace-nested-export/types.d.ts
+++ b/tests/testcases/namespace-nested-export/types.d.ts
@@ -1,0 +1,3 @@
+export interface External {
+  id: string;
+}

--- a/tests/testcases/namespace-nested-shadowing/expected.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/expected.d.ts
@@ -1,0 +1,10 @@
+interface TargetType {
+  version: 'v2';
+}
+declare namespace Outer {
+  namespace Inner {
+    type ShadowedType = TargetType;
+    export type Result = ShadowedType;
+  }
+}
+export { Outer };

--- a/tests/testcases/namespace-nested-shadowing/index.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/index.d.ts
@@ -1,0 +1,13 @@
+import * as Types from "./types";
+
+// This interface should be tree-shaken away because it's never used.
+interface ShadowedType {
+  version: 'v1';
+}
+
+export namespace Outer {
+  export namespace Inner {
+    import ShadowedType = Types.TargetType;
+    export type Result = ShadowedType;
+  }
+}

--- a/tests/testcases/namespace-nested-shadowing/meta.js
+++ b/tests/testcases/namespace-nested-shadowing/meta.js
@@ -1,0 +1,6 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/namespace-nested-shadowing/types.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/types.d.ts
@@ -1,0 +1,3 @@
+export interface TargetType {
+  version: 'v2';
+}


### PR DESCRIPTION
Added support for `import` alias declarations (e.g. `import Alias = Other.Type`) inside `declare namespace` blocks:
- Update `DeclarationScope` to correctly hoist and resolve references from child imports within a namespace.
- New recursive pre-processing step to correctly handle arbitrarily nested namespaces.
- Refactor of the modifier fixing logic to be context-aware, preventing regressions in `declare module` and `declare global` blocks by applying different rules to top-level vs nested declarations.

Added new tests:

- `namespace-child-import`
	This is the foundational "happy path" test. It confirms the most basic requirement: a simple `import =` alias inside a single namespace is correctly rewritten to `type =`.

- `namespace-nested-shadowing`

	This is a complex scenario test. It validates three critical behaviors at once:
	1. The logic is recursive (handles nesting).
	2. The scope analysis correctly handles an alias shadowing an outer type.
	3. Tree-shaking correctly removes the unused (shadowed) type.

- `namespace-function-alias`

	This covers the specific edge case from the [`node-fetch` types](https://app.unpkg.com/@types/node-fetch@2.6.13/files/index.d.ts#L235). It asserts that an import alias pointing to a local identifier is correctly preserved, preventing the bug we fixed.

- `namespace-nested-export`

	This test confirms that export keywords on members inside a nested namespace are correctly preserved, which was a key part of the regression fix.
