### PR TITLE
fix(transform): preserve `import =` in namespaces

### DIFF
--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -27,18 +27,8 @@ function preProcessNamespaceBody(body: ts.ModuleBlock, code: MagicString, source
       duplicateExports(code, stmt);
     }
 
-    // Rewrite `import =` to `type =`
-    if (
-      ts.isImportEqualsDeclaration(stmt) &&
-      // Add this condition to avoid rewriting local aliases
-      !ts.isIdentifier(stmt.moduleReference)
-    ) {
-      const importKeyword = stmt.getChildren().find((child) => child.kind === ts.SyntaxKind.ImportKeyword);
-      if (importKeyword) {
-        code.overwrite(importKeyword.getStart(sourceFile), importKeyword.getEnd(), "type");
-      }
-    } else if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) {
-      // Recurse for nested namespaces
+    // Recurse for nested namespaces
+    if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) {
       preProcessNamespaceBody(stmt.body, code, sourceFile);
     }
   }

--- a/tests/testcases/namespace-child-import/expected.d.ts
+++ b/tests/testcases/namespace-child-import/expected.d.ts
@@ -2,7 +2,8 @@ interface AnInterface {
   prop: number;
 }
 declare namespace Bar {
-  type Baz = AnInterface;
+  // Basic import alias inside namespace
+  import Baz = AnInterface;
   export type Qux = Baz;
 }
 export { Bar };

--- a/tests/testcases/namespace-child-import/index.d.ts
+++ b/tests/testcases/namespace-child-import/index.d.ts
@@ -1,6 +1,7 @@
 import * as Foo from "./foo";
 
 export namespace Bar {
+  // Basic import alias inside namespace
   import Baz = Foo.AnInterface;
   export type Qux = Baz;
 }

--- a/tests/testcases/namespace-function-alias/expected.d.ts
+++ b/tests/testcases/namespace-function-alias/expected.d.ts
@@ -1,7 +1,7 @@
 declare function myFunc(arg: string): void;
 // Augment the function with a namespace
 declare namespace myFunc {
-  // Create an alias to the outer function for re-exporting as default
+  // Local identifier alias (not qualified name) must preserve `import` keyword
   import _default = myFunc;
   export { _default as default };
   export const SOME_PROP = 123;

--- a/tests/testcases/namespace-function-alias/index.d.ts
+++ b/tests/testcases/namespace-function-alias/index.d.ts
@@ -2,7 +2,7 @@ export declare function myFunc(arg: string): void;
 
 // Augment the function with a namespace
 export declare namespace myFunc {
-  // Create an alias to the outer function for re-exporting as default
+  // Local identifier alias (not qualified name) must preserve `import` keyword
   import _default = myFunc;
   export { _default as default };
 

--- a/tests/testcases/namespace-nested-export/expected.d.ts
+++ b/tests/testcases/namespace-nested-export/expected.d.ts
@@ -3,7 +3,8 @@ interface External {
 }
 declare namespace Container {
   namespace Nested {
-    type Local = External;
+    // Import inside nested namespace with export keyword preserved
+    import Local = External;
     export type FinalType = Local;
   }
 }

--- a/tests/testcases/namespace-nested-export/index.d.ts
+++ b/tests/testcases/namespace-nested-export/index.d.ts
@@ -2,6 +2,7 @@ import * as Types from './types';
 
 export namespace Container {
   export namespace Nested {
+    // Import inside nested namespace with export keyword preserved
     import Local = Types.External;
     export type FinalType = Local;
   }

--- a/tests/testcases/namespace-nested-shadowing/expected.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/expected.d.ts
@@ -3,7 +3,8 @@ interface TargetType {
 }
 declare namespace Outer {
   namespace Inner {
-    type ShadowedType = TargetType;
+    // Import shadows outer interface, verifies scoping and tree-shaking
+    import ShadowedType = TargetType;
     export type Result = ShadowedType;
   }
 }

--- a/tests/testcases/namespace-nested-shadowing/index.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/index.d.ts
@@ -7,6 +7,7 @@ interface ShadowedType {
 
 export namespace Outer {
   export namespace Inner {
+    // Import shadows outer interface, verifies scoping and tree-shaking
     import ShadowedType = Types.TargetType;
     export type Result = ShadowedType;
   }

--- a/tests/testcases/namespace-reexport-interface/expected.d.ts
+++ b/tests/testcases/namespace-reexport-interface/expected.d.ts
@@ -1,0 +1,17 @@
+// Source namespace with interface and nested namespace
+declare namespace ArrayObjectStore {
+  export interface Data {
+    id: string;
+    value: number;
+  }
+  namespace Util {
+    export function helper(): void;
+  }
+}
+// Re-export interface and namespace from another namespace
+// `import` maintains interface semantics, while `type` would create type alias
+declare namespace CrudArrayObjectStore {
+  export import Data = ArrayObjectStore.Data;
+  export import Util = ArrayObjectStore.Util;
+}
+export { CrudArrayObjectStore };

--- a/tests/testcases/namespace-reexport-interface/index.d.ts
+++ b/tests/testcases/namespace-reexport-interface/index.d.ts
@@ -1,0 +1,8 @@
+import * as Store from './types';
+
+// Re-export interface and namespace from another namespace
+// `import` maintains interface semantics, while `type` would create type alias
+export namespace CrudArrayObjectStore {
+  export import Data = Store.ArrayObjectStore.Data;
+  export import Util = Store.ArrayObjectStore.Util;
+}

--- a/tests/testcases/namespace-reexport-interface/types.d.ts
+++ b/tests/testcases/namespace-reexport-interface/types.d.ts
@@ -1,0 +1,11 @@
+// Source namespace with interface and nested namespace
+export namespace ArrayObjectStore {
+  export interface Data {
+    id: string;
+    value: number;
+  }
+
+  export namespace Util {
+    export function helper(): void;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Swatinem/rollup-plugin-dts/pull/352#issuecomment-3283535379 where import alias declarations inside namespaces were being rewritten as type aliases, changing their meaning.

Previously, `export import Data = ArrayObjectStore.Data` (an `interface`) was converted into a `type` alias, which breaks type identity and confuses tools like IDEs and doc generators. The transformer already handles import equals correctly, so this conversion was unnecessary.

The fix removes the `import` to `type` rewrite in `preProcessNamespaceBody`. Tests for namespace child imports, nested exports, and shadowing now preserve import, and a new case (`namespace-reexport-interface`) confirms interfaces re-export properly.

Thanks @typhonrt for pointing this out and providing a real example.
