### PR TITLE
feat(transform): support default export of object/array literals

### DIFF
--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -196,7 +196,36 @@ class Transformer {
 
       const scope = this.createDeclaration(node, decl.name);
       scope.convertTypeNode(decl.type);
+
+      // Track references in the initializer (e.g., for object literals)
+      if (decl.initializer) {
+        this.trackExpressionReferences(decl.initializer, scope);
+      }
     }
+  }
+
+  // Helper to track identifier references in expressions
+  private trackExpressionReferences(expr: ts.Expression, scope: DeclarationScope) {
+    if (ts.isIdentifier(expr)) {
+      scope.pushIdentifierReference(expr);
+    } else if (ts.isObjectLiteralExpression(expr)) {
+      for (const prop of expr.properties) {
+        if (ts.isShorthandPropertyAssignment(prop)) {
+          scope.pushIdentifierReference(prop.name);
+        } else if (ts.isPropertyAssignment(prop)) {
+          this.trackExpressionReferences(prop.initializer, scope);
+        }
+      }
+    } else if (ts.isArrayLiteralExpression(expr)) {
+      for (const elem of expr.elements) {
+        if (ts.isExpression(elem)) {
+          this.trackExpressionReferences(elem, scope);
+        }
+      }
+    } else if (ts.isPropertyAccessExpression(expr)) {
+      this.trackExpressionReferences(expr.expression, scope);
+    }
+    // Add more expression types as needed
   }
 
   convertExportDeclaration(node: ts.ExportDeclaration | ts.ExportAssignment) {

--- a/src/transform/Transformer.ts
+++ b/src/transform/Transformer.ts
@@ -225,7 +225,6 @@ class Transformer {
     } else if (ts.isPropertyAccessExpression(expr)) {
       this.trackExpressionReferences(expr.expression, scope);
     }
-    // Add more expression types as needed
   }
 
   convertExportDeclaration(node: ts.ExportDeclaration | ts.ExportAssignment) {

--- a/src/transform/astHelpers.ts
+++ b/src/transform/astHelpers.ts
@@ -138,6 +138,45 @@ export function convertExpression(node: ts.Expression): ESTree.Expression {
       },
     );
   }
+  if (ts.isObjectLiteralExpression(node)) {
+    return withStartEnd(
+      {
+        type: "ObjectExpression",
+        properties: node.properties.map((prop) => {
+          if (ts.isPropertyAssignment(prop)) {
+            return withStartEnd(
+              {
+                type: "Property",
+                key: ts.isIdentifier(prop.name) ? createIdentifier(prop.name) : convertExpression(prop.name as ts.Expression),
+                value: convertExpression(prop.initializer),
+                kind: "init",
+                method: false,
+                shorthand: false,
+                computed: ts.isComputedPropertyName(prop.name),
+              } as ESTree.Property,
+              prop,
+            );
+          } else if (ts.isShorthandPropertyAssignment(prop)) {
+            return withStartEnd(
+              {
+                type: "Property",
+                key: createIdentifier(prop.name),
+                value: createIdentifier(prop.name),
+                kind: "init",
+                method: false,
+                shorthand: true,
+                computed: false,
+              } as ESTree.Property,
+              prop,
+            );
+          } else {
+            throw new UnsupportedSyntaxError(prop, "Unsupported property type in object literal");
+          }
+        }),
+      },
+      node,
+    );
+  }
   if (ts.isIdentifier(node)) {
     return createIdentifier(node);
   } else if (node.kind == ts.SyntaxKind.NullKeyword) {

--- a/src/transform/astHelpers.ts
+++ b/src/transform/astHelpers.ts
@@ -177,6 +177,21 @@ export function convertExpression(node: ts.Expression): ESTree.Expression {
       node,
     );
   }
+  if (ts.isArrayLiteralExpression(node)) {
+    return withStartEnd(
+      {
+        type: "ArrayExpression",
+        elements: node.elements.map((elem) => {
+          if (ts.isExpression(elem)) {
+            return convertExpression(elem);
+          } else {
+            throw new UnsupportedSyntaxError(elem, "Unsupported element type in array literal");
+          }
+        }),
+      },
+      node,
+    );
+  }
   if (ts.isIdentifier(node)) {
     return createIdentifier(node);
   } else if (node.kind == ts.SyntaxKind.NullKeyword) {

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -224,17 +224,14 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     // transformTypeOnlyImport(node);
     // transformTypeOnlyExport(node);
 
-    // Handle export assignments (export default expression)
+    // Handle export default with object/array literals
+    // These need to be converted to named declarations so Rollup can track references within them
     if (ts.isExportAssignment(node) && !node.isExportEquals) {
-      // Only handle complex expressions like object literals
-      // Simple identifiers can be handled by the normal export mechanism
-      if (ts.isObjectLiteralExpression(node.expression)) {
-        // For export default with an object literal,
-        // create a named declaration so Rollup can track references
+      if (ts.isObjectLiteralExpression(node.expression) || ts.isArrayLiteralExpression(node.expression)) {
         if (!defaultExport) {
           defaultExport = uniqName("export_default");
         }
-        // Remove the "export default" part and create a var declaration instead
+        // Replace "export default" with "declare var export_default ="
         code.overwrite(node.getStart(), node.expression.getStart(), `declare var ${defaultExport} = `);
         continue;
       }

--- a/tests/testcases/default-export-array/expected.d.ts
+++ b/tests/testcases/default-export-array/expected.d.ts
@@ -1,0 +1,9 @@
+declare const hstack: string;
+declare const vstack: string;
+declare const visuallyHidden: string;
+declare var export_default = [
+    hstack,
+    vstack,
+    visuallyHidden
+];
+export { export_default as default };

--- a/tests/testcases/default-export-array/index.d.ts
+++ b/tests/testcases/default-export-array/index.d.ts
@@ -1,0 +1,9 @@
+const hstack: string;
+const vstack: string;
+const visuallyHidden: string;
+
+export default [
+    hstack,
+    vstack,
+    visuallyHidden
+];

--- a/tests/testcases/default-export-nested/expected.d.ts
+++ b/tests/testcases/default-export-nested/expected.d.ts
@@ -1,0 +1,9 @@
+declare const theme: {
+    colors: {
+        primary: string;
+    };
+};
+declare var export_default = {
+    mainTheme: theme
+};
+export { export_default as default };

--- a/tests/testcases/default-export-nested/index.d.ts
+++ b/tests/testcases/default-export-nested/index.d.ts
@@ -1,0 +1,9 @@
+const theme: {
+    colors: {
+        primary: string;
+    };
+};
+
+export default {
+    mainTheme: theme
+};

--- a/tests/testcases/default-export-object/expected.d.ts
+++ b/tests/testcases/default-export-object/expected.d.ts
@@ -1,0 +1,9 @@
+declare const hstack: string;
+declare const vstack: string;
+declare const visuallyHidden: string;
+declare var export_default = {
+    hstack,
+    vstack,
+    visuallyHidden
+};
+export { export_default as default };

--- a/tests/testcases/default-export-object/index.d.ts
+++ b/tests/testcases/default-export-object/index.d.ts
@@ -1,0 +1,9 @@
+const hstack: string;
+const vstack: string;
+const visuallyHidden: string;
+
+export default {
+    hstack,
+    vstack,
+    visuallyHidden
+};


### PR DESCRIPTION
## Problem

When bundling `.d.ts` files with export default followed by object or array literals, the plugin would fail to handle these expressions. This pattern is valid TypeScript:

```ts
const foo: string;
const bar: string;

export default { foo, bar };  // Object literal
export default [foo, bar];     // Array literal
export default { nested: { foo, bar } }; // Nested object literal
```

Previously, the plugin couldn't:
1. Convert default exports with complex literals into trackable declarations
2. Track identifier references within object/array literals (e.g. shorthand properties, array elements)
3. Convert these literal expressions to the virtual AST format

## Changes

- `preprocess.ts`: Added handling for export default with object/array literals by converting them to named declarations (`declare var export_default = {...}`) so Rollup can
track references
- `Transformer.ts`: Added `trackExpressionReferences()` method to recursively track identifier references in expressions (object literals, array literals, property access)
- `astHelpers.ts`: Added `convertExpression()` support for object literals (shorthand & regular properties) and array literals
- Added test cases:
  - `default-export-object` - object literal with shorthand properties
  - `default-export-array` - array literal with identifiers
  - `default-export-nested` - object literal with nested property assignment
