### PR TITLE
fix(transform): preserve export keywords on nested namespaces

### DIFF
--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -23,10 +23,6 @@ function preProcessNamespaceBody(body: ts.ModuleBlock, code: MagicString, source
     // Safely call the new context-aware function on all children
     fixModifiers(code, stmt);
 
-    if (ts.isModuleDeclaration(stmt)) {
-      duplicateExports(code, stmt);
-    }
-
     // Recurse for nested namespaces
     if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) {
       preProcessNamespaceBody(stmt.body, code, sourceFile);
@@ -593,16 +589,8 @@ function fixModifiers(code: MagicString, node: ts.Node) {
     if (needsDeclare && !hasDeclare) {
       code.appendRight(node.getStart(), "declare ");
     }
-  } else {
-    // For statements inside a namespace/module, only remove `export` from a nested namespace
-    // Leave all other members (vars, types, etc.) untouched
-    if (ts.isModuleDeclaration(node)) {
-      const exportKeyword = node.modifiers?.find((mod) => mod.kind === ts.SyntaxKind.ExportKeyword);
-      if (exportKeyword) {
-        code.remove(exportKeyword.getStart(), exportKeyword.getEnd() + 1);
-      }
-    }
   }
+  // For statements inside namespaces, preserve all modifiers (including export)
 }
 
 function duplicateExports(code: MagicString, module: ts.ModuleDeclaration) {

--- a/tests/testcases/namespace-nested-export/expected.d.ts
+++ b/tests/testcases/namespace-nested-export/expected.d.ts
@@ -2,7 +2,7 @@ interface External {
   id: string;
 }
 declare namespace Container {
-  namespace Nested {
+  export namespace Nested {
     // Import inside nested namespace with export keyword preserved
     import Local = External;
     export type FinalType = Local;

--- a/tests/testcases/namespace-nested-shadowing/expected.d.ts
+++ b/tests/testcases/namespace-nested-shadowing/expected.d.ts
@@ -2,7 +2,7 @@ interface TargetType {
   version: 'v2';
 }
 declare namespace Outer {
-  namespace Inner {
+  export namespace Inner {
     // Import shadows outer interface, verifies scoping and tree-shaking
     import ShadowedType = TargetType;
     export type Result = ShadowedType;

--- a/tests/testcases/namespace-reexport-interface/expected.d.ts
+++ b/tests/testcases/namespace-reexport-interface/expected.d.ts
@@ -4,7 +4,7 @@ declare namespace ArrayObjectStore {
     id: string;
     value: number;
   }
-  namespace Util {
+  export namespace Util {
     export function helper(): void;
   }
 }


### PR DESCRIPTION
Fixes #359

Removes two problematic code sections from PR #352:

1. **Lines 26-28**: Unnecessary `duplicateExports()` call that caused superfluous export name duplication in namespace bodies

2. **Lines 596-605**: Incorrect removal of export keywords from nested namespaces, which changed their accessibility from public to private

## Problem

The previous implementation was removing `export` keywords from nested namespaces, which:
- Changed nested namespaces from public to private scope
- Broke downstream consumption where nested namespaces were accessed
- Broke API documentation which relied on exported namespaces  
- Violated the plugin's philosophy: bundle declarations, not transform semantics

## Changes

- Removed unnecessary `duplicateExports()` invocation in `preProcessNamespaceBody()`
- Removed the `else` block in `fixModifiers()` that stripped `export` from nested namespaces
- Updated test expectations to preserve `export` keywords on nested namespaces