### PR TITLE
fix(transform): Use chunk fileName to determine transformed module name  for relative `declare module` blocks

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -145,7 +145,7 @@ export const transform = () => {
         chunk.fileName,
         "magicCode" in typesFixed && typesFixed.magicCode ? typesFixed.magicCode : new MagicString(code),
         !!options.sourcemap,
-        "./" + (options.file && options.file !== "-" ? path.basename(options.file, ".d.ts") : "index"),
+        "./" + path.basename(chunk.fileName, ".d.ts"),
       );
 
       return relativeModuleDeclarationFixed.fix();

--- a/tests/testcases/declare-relative-module/expected.d.ts
+++ b/tests/testcases/declare-relative-module/expected.d.ts
@@ -1,7 +1,7 @@
 interface Foo {
   someProp: boolean;
 }
-declare module "./index" {
+declare module "./expected.d" {
   interface Foo {
     anotherProp: string;
   }

--- a/tests/testcases/declare-relative-module/meta.js
+++ b/tests/testcases/declare-relative-module/meta.js
@@ -1,0 +1,16 @@
+const options = {
+  rollupOptions: {
+    input: {
+      // The sanity check creates another bundle with `expected.d.ts` as the
+      // input file name. This results in a chunk name of `expected.d.d.ts` as
+      // rollup will first strip extname (i.e. `.ts`) and then add `.d.ts`
+      // again. This results in a module name of `./expected.d`. To make sure
+      // both, the initial bundle and the sanity check bundle, have the same
+      // module names, we need to explicitly set the chunk name to
+      // `expected.d` here.
+      'expected.d': 'index.d.ts'
+    }
+  }
+};
+
+export default options;


### PR DESCRIPTION
The original code used to determine the transformed module name in `declare module` blocks with a relative reference used the `file` option passed to rollup with a default fallback. This does not work when that option is not provided, e.g. when `dir` is used instead or when multiple chunks are generated.

The fix determines the target module name based on the `fileName` property of the current chunk, instead.