### PR TITLE
fix: rewrite shared chunk imports for TS2742 portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ bundling. This can be overridden using the `respectExternal` setting, but it is
 generally not recommended. While rollup of external `@types` generally works,
 it is not recommended.
 
+### TS2742 and shared declaration chunks
+
+When a bundled entry exposes a type that originally came from a private shared
+chunk, downstream `tsc --declaration` runs can fail with `TS2742`.
+
+This is part of a broader TypeScript declaration portability problem. For
+upstream context, see
+[`./*.d.ts` required in `exports` to avoid `...not portable...`](https://github.com/microsoft/TypeScript/issues/60913)
+for one shape of the bug, and
+[`Elaborate on non-portable types`](https://github.com/microsoft/TypeScript/issues/53764)
+for the related error-message discussion.
+
+This plugin will try to rewrite that path through an entry that already
+re-exports the type publicly. That keeps the existing public API and can make
+the bundled declarations portable for downstream consumers.
+
+The plugin does **not** invent new public exports. If no public entry re-exports
+the shared type, the bundled package can still trigger `TS2742`. In that case,
+the plugin emits a warning and the package should re-export the type from a
+public entry explicitly.
+
 ## Why?
 
 Well, ideally TypeScript should just do all this itself, and it even has a

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { Plugin, SourceMap } from "rollup";
+import type { OutputBundle, Plugin, SourceMap } from "rollup";
 import remapping from "@jridgewell/remapping";
 import type { RawSourceMap } from "@jridgewell/remapping";
 import { NamespaceFixer } from "./NamespaceFixer.js";
@@ -10,6 +10,7 @@ import { parse, trimExtension, JSON_EXTENSIONS, DTS_EXTENSIONS } from "../helper
 import { ModuleDeclarationFixer } from "./ModuleDeclarationFixer.js";
 import MagicString from "magic-string";
 import { loadInputSourcemap, hydrateSourcemap, type InputSourceMap, type SourcemapInfo } from "./sourcemap.js";
+import { rewritePortableSharedChunkImportsInBundle } from "./sharedChunkPortability.js";
 
 /**
  * This is the *transform* part of `rollup-plugin-dts`.
@@ -197,6 +198,11 @@ export const transform = (enableSourcemap: boolean) => {
     },
 
     async generateBundle(options, bundle) {
+      rewritePortableSharedChunkImportsInBundle(
+        bundle,
+        (message) => this.warn(message),
+      );
+
       // Fix sourcemap sources to point to original .ts files
       // When input .d.ts files have associated .d.ts.map files pointing to original .ts sources,
       // we use sourcemap remapping to compose the transform's map with the input map
@@ -402,7 +408,7 @@ type SourcemapData = {
 };
 
 function updateSourcemapAsset(
-  bundle: Record<string, { type: string; source?: string }>,
+  bundle: OutputBundle,
   chunkFileName: string,
   data: SourcemapData,
 ) {

--- a/src/transform/sharedChunkPortability.ts
+++ b/src/transform/sharedChunkPortability.ts
@@ -1,0 +1,433 @@
+import * as path from "node:path";
+import type { OutputBundle, OutputChunk, SourceMap } from "rollup";
+import remapping from "@jridgewell/remapping";
+import type { RawSourceMap } from "@jridgewell/remapping";
+import ts from "typescript";
+import MagicString from "magic-string";
+import { parse } from "../helpers.js";
+
+type ChunkGraphInfo = {
+  exports: string[];
+  isEntry: boolean;
+};
+
+type ImportSpecifierInfo = {
+  importedName: string;
+  isTypeOnly: boolean;
+  localName: string;
+};
+
+type ImportStatementInfo = {
+  isTypeOnly: boolean;
+  moduleSpecifier: string;
+  quote: "'" | '"';
+  specifiers: ImportSpecifierInfo[];
+  statement: ts.ImportDeclaration;
+};
+
+type ImportBinding = {
+  importedName: string;
+  isTypeOnly: boolean;
+  moduleSpecifier: string;
+};
+
+type HostExportRoute = {
+  exportedName: string;
+  isTypeOnly: boolean;
+};
+
+type ChunkAnalysis = {
+  hostRoutesByModule: Map<string, Map<string, HostExportRoute[]>>;
+  importStatements: ImportStatementInfo[];
+};
+
+export function rewritePortableSharedChunkImportsInBundle(
+  bundle: OutputBundle,
+  warn: (message: string) => void,
+) {
+  const chunks = Object.values(bundle).filter(isOutputChunk);
+  const sharedChunks = chunks.filter((chunk) => !chunk.isEntry);
+  if (sharedChunks.length === 0) return;
+
+  const entryChunks = chunks.filter((chunk) => chunk.isEntry);
+  const chunkGraph = new Map<string, ChunkGraphInfo>(
+    chunks.map((chunk) => [
+      chunk.fileName,
+      {
+        exports: chunk.exports,
+        isEntry: chunk.isEntry,
+      },
+    ]),
+  );
+  const analyses = new Map<string, ChunkAnalysis>(
+    chunks.map((chunk) => [chunk.fileName, analyzeChunk(chunk, chunkGraph)]),
+  );
+
+  for (const chunk of entryChunks) {
+    const analysis = analyses.get(chunk.fileName)!;
+    const magicCode = new MagicString(chunk.code);
+    let hasChanges = false;
+    const unresolvedSymbols = new Set<string>();
+
+    for (const statement of analysis.importStatements) {
+      const sharedChunk = sharedChunks.find(
+        (candidate) => getChunkImportSpecifier(chunk.fileName, candidate.fileName) === statement.moduleSpecifier,
+      );
+      if (!sharedChunk) {
+        continue;
+      }
+
+      const keptSpecifiers: ImportSpecifierInfo[] = [];
+      const rewrittenSpecifiers = new Map<string, ImportSpecifierInfo[]>();
+
+      for (const specifier of statement.specifiers) {
+        if (hasPublicHostRoute(analysis, statement.moduleSpecifier, specifier.importedName)) {
+          keptSpecifiers.push(specifier);
+          continue;
+        }
+
+        const hostCandidate = pickHostCandidate(
+          entryChunks,
+          analyses,
+          chunk.fileName,
+          sharedChunk.fileName,
+          specifier,
+        );
+
+        if (!hostCandidate) {
+          keptSpecifiers.push(specifier);
+          unresolvedSymbols.add(specifier.localName);
+          continue;
+        }
+
+        const hostSpecifier = getChunkImportSpecifier(chunk.fileName, hostCandidate.chunk.fileName);
+        const hostImportSpecifiers = rewrittenSpecifiers.get(hostSpecifier) || [];
+        hostImportSpecifiers.push({
+          importedName: hostCandidate.exportedName,
+          isTypeOnly: specifier.isTypeOnly || hostCandidate.isTypeOnly,
+          localName: specifier.localName,
+        });
+        rewrittenSpecifiers.set(hostSpecifier, hostImportSpecifiers);
+      }
+
+      if (!rewrittenSpecifiers.size) {
+        continue;
+      }
+
+      const replacementStatements: string[] = [];
+
+      if (keptSpecifiers.length) {
+        replacementStatements.push(buildImportStatement(statement, keptSpecifiers, statement.moduleSpecifier, statement.quote));
+      }
+
+      const hostSpecifiers = Array.from(rewrittenSpecifiers.keys()).sort(compareStrings);
+      for (const hostSpecifier of hostSpecifiers) {
+        replacementStatements.push(
+          buildImportStatement(statement, rewrittenSpecifiers.get(hostSpecifier)!, hostSpecifier, statement.quote),
+        );
+      }
+
+      magicCode.overwrite(
+        statement.statement.getStart(),
+        statement.statement.getEnd(),
+        replacementStatements.join("\n"),
+      );
+      hasChanges = true;
+    }
+
+    if (hasChanges) {
+      applyChunkEdits(chunk, magicCode);
+    }
+
+    if (unresolvedSymbols.size) {
+      warn(formatUnresolvedSharedTypeWarning(chunk.fileName, unresolvedSymbols));
+    }
+  }
+}
+
+function analyzeChunk(
+  chunk: Pick<OutputChunk, "code" | "exports" | "fileName">,
+  chunkGraph: Map<string, ChunkGraphInfo>,
+): ChunkAnalysis {
+  const source = parse(chunk.fileName, chunk.code);
+  const importStatements: ImportStatementInfo[] = [];
+  const importedBindings = new Map<string, ImportBinding>();
+  const hostRoutesByModule = new Map<string, Map<string, HostExportRoute[]>>();
+  const starExports: string[] = [];
+
+  for (const statement of source.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      !statement.importClause?.name &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.importClause?.namedBindings &&
+      ts.isNamedImports(statement.importClause.namedBindings)
+    ) {
+      const moduleSpecifier = statement.moduleSpecifier.text;
+      const quote = statement.moduleSpecifier.getText(source).startsWith('"') ? '"' : "'";
+      const specifiers = statement.importClause.namedBindings.elements.map((element) => {
+        const specifier = {
+          importedName: element.propertyName?.text || element.name.text,
+          isTypeOnly: element.isTypeOnly || statement.importClause?.isTypeOnly || false,
+          localName: element.name.text,
+        };
+        importedBindings.set(specifier.localName, {
+          importedName: specifier.importedName,
+          isTypeOnly: specifier.isTypeOnly,
+          moduleSpecifier,
+        });
+        return specifier;
+      });
+
+      importStatements.push({
+        isTypeOnly: statement.importClause.isTypeOnly,
+        moduleSpecifier,
+        quote,
+        specifiers,
+        statement,
+      });
+      continue;
+    }
+
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) {
+      continue;
+    }
+
+    if (!statement.exportClause) {
+      starExports.push(statement.moduleSpecifier.text);
+      continue;
+    }
+
+    if (!ts.isNamedExports(statement.exportClause)) {
+      continue;
+    }
+
+    for (const element of statement.exportClause.elements) {
+      addHostExportRoute(
+        hostRoutesByModule,
+        statement.moduleSpecifier.text,
+        element.propertyName?.text || element.name.text,
+        {
+          exportedName: element.name.text,
+          isTypeOnly: statement.isTypeOnly || element.isTypeOnly,
+        },
+      );
+    }
+  }
+
+  for (const statement of source.statements) {
+    if (
+      !ts.isExportDeclaration(statement) ||
+      statement.moduleSpecifier ||
+      !statement.exportClause ||
+      !ts.isNamedExports(statement.exportClause)
+    ) {
+      continue;
+    }
+
+    for (const element of statement.exportClause.elements) {
+      const localName = element.propertyName?.text || element.name.text;
+      const binding = importedBindings.get(localName);
+      if (!binding) {
+        continue;
+      }
+
+      addHostExportRoute(hostRoutesByModule, binding.moduleSpecifier, binding.importedName, {
+        exportedName: element.name.text,
+        isTypeOnly: binding.isTypeOnly || statement.isTypeOnly || element.isTypeOnly,
+      });
+    }
+  }
+
+  for (const moduleSpecifier of starExports) {
+    const sharedChunk = Array.from(chunkGraph.entries()).find(
+      ([candidateFileName, candidate]) => !candidate.isEntry && getChunkImportSpecifier(chunk.fileName, candidateFileName) === moduleSpecifier,
+    );
+    if (!sharedChunk) {
+      continue;
+    }
+
+    for (const exportedName of sharedChunk[1].exports) {
+      if (exportedName === "default") {
+        continue;
+      }
+
+      addHostExportRoute(hostRoutesByModule, moduleSpecifier, exportedName, {
+        exportedName,
+        isTypeOnly: false,
+      });
+    }
+  }
+
+  return {
+    hostRoutesByModule,
+    importStatements,
+  };
+}
+
+const isOutputChunk = (chunk: { type: string }): chunk is OutputChunk => chunk.type === "chunk";
+
+function pickHostCandidate(
+  entryChunks: OutputChunk[],
+  analyses: Map<string, ChunkAnalysis>,
+  currentChunkFileName: string,
+  sharedChunkFileName: string,
+  specifier: ImportSpecifierInfo,
+) {
+  const candidates: Array<HostExportRoute & { chunk: OutputChunk }> = [];
+
+  for (const hostChunk of entryChunks) {
+    if (hostChunk.fileName === currentChunkFileName) {
+      continue;
+    }
+
+    const hostAnalysis = analyses.get(hostChunk.fileName)!;
+    const sharedSpecifier = getChunkImportSpecifier(hostChunk.fileName, sharedChunkFileName);
+    const routes = getHostExportRoutes(hostAnalysis, sharedSpecifier, specifier.importedName);
+
+    for (const route of routes) {
+      candidates.push({
+        ...route,
+        chunk: hostChunk,
+      });
+    }
+  }
+
+  candidates.sort((left, right) => {
+    const leftMatchesLocal = left.exportedName === specifier.localName ? 0 : 1;
+    const rightMatchesLocal = right.exportedName === specifier.localName ? 0 : 1;
+    if (leftMatchesLocal !== rightMatchesLocal) {
+      return leftMatchesLocal - rightMatchesLocal;
+    }
+
+    const fileNameOrder = compareStrings(left.chunk.fileName, right.chunk.fileName);
+    if (fileNameOrder !== 0) {
+      return fileNameOrder;
+    }
+
+    return compareStrings(left.exportedName, right.exportedName);
+  });
+
+  return candidates[0];
+}
+
+const getHostExportRoutes = (analysis: ChunkAnalysis, moduleSpecifier: string, importedName: string) =>
+  analysis.hostRoutesByModule.get(moduleSpecifier)?.get(importedName) || [];
+
+const hasPublicHostRoute = (analysis: ChunkAnalysis, moduleSpecifier: string, importedName: string) =>
+  getHostExportRoutes(analysis, moduleSpecifier, importedName).length > 0;
+
+const compareStrings = (left: string, right: string) => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+};
+
+function addHostExportRoute(
+  hostRoutesByModule: Map<string, Map<string, HostExportRoute[]>>,
+  moduleSpecifier: string,
+  importedName: string,
+  route: HostExportRoute,
+) {
+  const routesByImportedName = hostRoutesByModule.get(moduleSpecifier) || new Map<string, HostExportRoute[]>();
+  const routes = routesByImportedName.get(importedName) || [];
+
+  if (!routes.some((existing) => existing.exportedName === route.exportedName && existing.isTypeOnly === route.isTypeOnly)) {
+    routes.push(route);
+  }
+
+  routesByImportedName.set(importedName, routes);
+  hostRoutesByModule.set(moduleSpecifier, routesByImportedName);
+}
+
+function buildImportStatement(
+  statement: ImportStatementInfo,
+  specifiers: ImportSpecifierInfo[],
+  moduleSpecifier: string,
+  quote: "'" | '"',
+) {
+  const useTypeOnlyImport = statement.isTypeOnly || specifiers.every((specifier) => specifier.isTypeOnly);
+  const importKeyword = useTypeOnlyImport ? "import type" : "import";
+  const namedImports = specifiers
+    .map((specifier) => {
+      const prefix = !useTypeOnlyImport && specifier.isTypeOnly ? "type " : "";
+      if (specifier.importedName === specifier.localName) {
+        return `${prefix}${specifier.importedName}`;
+      }
+      return `${prefix}${specifier.importedName} as ${specifier.localName}`;
+    })
+    .join(", ");
+
+  return `${importKeyword} { ${namedImports} } from ${quote}${moduleSpecifier}${quote};`;
+}
+
+function applyChunkEdits(chunk: Pick<OutputChunk, "code" | "fileName" | "map">, code: MagicString) {
+  const nextCode = code.toString();
+  if (nextCode === chunk.code) {
+    return;
+  }
+
+  if (chunk.map) {
+    const chunkFileName = normalizeChunkPath(chunk.fileName);
+    const rewriteMap = code.generateMap({
+      file: chunkFileName,
+      hires: true,
+      includeContent: true,
+      source: chunkFileName,
+    });
+    const remapped = remapping(rewriteMap as unknown as RawSourceMap, (file) => {
+      if (normalizeChunkPath(file) === chunkFileName) {
+        return chunk.map as unknown as RawSourceMap;
+      }
+      return null;
+    });
+
+    chunk.map = {
+      ...chunk.map,
+      mappings: typeof remapped.mappings === "string" ? remapped.mappings : "",
+      names: remapped.names || [],
+      sources: remapped.sources,
+    } as SourceMap;
+    delete (chunk.map as any).sourcesContent;
+  }
+
+  chunk.code = nextCode;
+}
+
+const formatUnresolvedSharedTypeWarning = (chunkFileName: string, symbols: Set<string>) => {
+  const symbolList = Array.from(symbols).sort().join(", ");
+  return [
+    `Entry "${chunkFileName}" still references private shared type exports with no public re-export: ${symbolList}.`,
+    "rollup-plugin-dts will not invent new public exports for these types.",
+    "Re-export them from a public entry to avoid downstream TS2742 errors.",
+  ].join(" ");
+};
+
+const getChunkImportSpecifier = (fromChunkFileName: string, toChunkFileName: string) => {
+  const fromDir = path.posix.dirname(normalizeChunkPath(fromChunkFileName));
+  const toRuntimeFileName = getChunkRuntimeFileName(normalizeChunkPath(toChunkFileName));
+  let relativePath = path.posix.relative(fromDir, toRuntimeFileName);
+  if (!relativePath.startsWith(".")) {
+    relativePath = `./${relativePath}`;
+  }
+  return relativePath;
+};
+
+const getChunkRuntimeFileName = (fileName: string) => {
+  if (fileName.endsWith(".d.mts")) {
+    return `${fileName.slice(0, -6)}.mjs`;
+  }
+  if (fileName.endsWith(".d.cts")) {
+    return `${fileName.slice(0, -6)}.cjs`;
+  }
+  if (fileName.endsWith(".d.ts")) {
+    return `${fileName.slice(0, -5)}.js`;
+  }
+  return `${fileName}.js`;
+};
+
+const normalizeChunkPath = (fileName: string) => fileName.replaceAll("\\", "/");

--- a/tests/downstream-helpers.ts
+++ b/tests/downstream-helpers.ts
@@ -1,0 +1,211 @@
+import * as assert from "assert";
+import { spawnSync } from "child_process";
+import fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import type { OutputChunk, RollupOutput } from "rollup";
+import { exists } from "./utils.js";
+
+export interface DownstreamCase {
+  consumer: string;
+  expectedDts?: string;
+  expectedError?: string;
+  expectedErrorIncludes?: string[];
+  compilerOptions?: {
+    module?: "NodeNext" | "ESNext";
+    moduleResolution?: "NodeNext" | "Bundler";
+    target?: "ESNext";
+    skipLibCheck?: boolean;
+  };
+}
+
+function clean(code: string = "") {
+  return (
+    code
+      .trim()
+      // skip blank lines
+      .replace(/\n+/gm, "\n") + "\n"
+  );
+}
+
+function isOutputChunk(output: RollupOutput["output"][number]): output is OutputChunk {
+  return output.type === "chunk";
+}
+
+function getRuntimeFileName(fileName: string) {
+  if (fileName.endsWith(".d.mts")) {
+    return fileName.slice(0, -6) + ".mjs";
+  }
+  if (fileName.endsWith(".d.cts")) {
+    return fileName.slice(0, -6) + ".cjs";
+  }
+  if (fileName.endsWith(".d.ts")) {
+    return fileName.slice(0, -5) + ".js";
+  }
+  return `${fileName}.js`;
+}
+
+function getPackageExportKeys(fileName: string) {
+  const normalizedFileName = fileName.replace(/\.d\.d(\.[mc]?ts)$/, ".d$1");
+  const declarationPath = normalizedFileName.replace(/\.d\.[mc]?ts$/, "").replace(/\\/g, "/");
+  if (declarationPath === "index") {
+    return [".", "./index"];
+  }
+  return [`./${declarationPath}`];
+}
+
+function formatDiagnostic(output: string, cwd: string) {
+  return output.trim().replaceAll(cwd + path.sep, "");
+}
+
+async function writeBundleAsPackage(packageDir: string, output: RollupOutput["output"]) {
+  const distDir = path.join(packageDir, "dist");
+  const exportsMap: Record<string, { types: string; default: string }> = {};
+
+  await fs.mkdir(distDir, { recursive: true });
+
+  for (const file of output.filter(isOutputChunk)) {
+    const declarationPath = path.join(distDir, file.fileName);
+    const runtimeFileName = getRuntimeFileName(file.fileName);
+    const runtimePath = path.join(distDir, runtimeFileName);
+
+    await fs.mkdir(path.dirname(declarationPath), { recursive: true });
+    await fs.mkdir(path.dirname(runtimePath), { recursive: true });
+    await fs.writeFile(declarationPath, clean(file.code));
+    await fs.writeFile(runtimePath, "export {};\n");
+
+    if (file.isEntry) {
+      for (const exportKey of getPackageExportKeys(file.fileName)) {
+        exportsMap[exportKey] = {
+          types: `./dist/${file.fileName.replace(/\\/g, "/")}`,
+          default: `./dist/${runtimeFileName.replace(/\\/g, "/")}`,
+        };
+      }
+    }
+  }
+
+  const packageJson: {
+    name: string;
+    type: "module";
+    exports: Record<string, { types: string; default: string }>;
+    main?: string;
+    types?: string;
+  } = {
+    name: "lib",
+    type: "module",
+    exports: exportsMap,
+  };
+  if (exportsMap["."]) {
+    packageJson.main = exportsMap["."].default;
+    packageJson.types = exportsMap["."].types;
+  }
+
+  await fs.writeFile(path.join(packageDir, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+export async function assertDownstream(
+  dir: string,
+  output: RollupOutput["output"],
+  downstream: DownstreamCase[],
+  bless: boolean,
+) {
+  const tscBin = path.resolve("node_modules/typescript/bin/tsc");
+
+  for (const testCase of downstream) {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rollup-plugin-dts-downstream-"));
+
+    try {
+      const consumerDir = path.join(tempRoot, "consumer");
+      const srcDir = path.join(consumerDir, "src");
+      const sourceFile = path.join(srcDir, "index.ts");
+      const packageDir = path.join(consumerDir, "node_modules", "lib");
+      const compilerOptions = {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        skipLibCheck: true,
+        target: "ESNext",
+        ...testCase.compilerOptions,
+      } as const;
+
+      await writeBundleAsPackage(packageDir, output);
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.writeFile(path.join(consumerDir, "package.json"), '{\n  "type": "module"\n}\n');
+      await fs.writeFile(sourceFile, await fs.readFile(path.join(dir, testCase.consumer), "utf-8"));
+
+      const emitArgs = [
+        tscBin,
+        "--declaration",
+        "--emitDeclarationOnly",
+        "--target",
+        compilerOptions.target,
+      ];
+      if (compilerOptions.skipLibCheck) {
+        emitArgs.push("--skipLibCheck");
+      }
+      emitArgs.push(
+        "--module",
+        compilerOptions.module,
+        "--moduleResolution",
+        compilerOptions.moduleResolution,
+        sourceFile,
+      );
+
+      const emit = spawnSync(process.execPath, emitArgs, {
+        cwd: consumerDir,
+        encoding: "utf8",
+      });
+      const diagnostic = formatDiagnostic(`${emit.stdout || ""}${emit.stderr || ""}`, consumerDir);
+
+      if (testCase.expectedError || testCase.expectedErrorIncludes?.length) {
+        assert.notStrictEqual(emit.status, 0, `Expected downstream consumer ${testCase.consumer} to fail`);
+        if (testCase.expectedError) {
+          assert.strictEqual(diagnostic, testCase.expectedError);
+        }
+        for (const expected of testCase.expectedErrorIncludes || []) {
+          assert.ok(
+            diagnostic.includes(expected),
+            `Expected downstream diagnostic to include ${JSON.stringify(expected)}.\nReceived:\n${diagnostic}`,
+          );
+        }
+        continue;
+      }
+
+      assert.strictEqual(emit.status, 0, diagnostic);
+      assert.ok(testCase.expectedDts, `Expected downstream success case ${testCase.consumer} to declare expectedDts`);
+
+      const emittedFile = path.join(srcDir, "index.d.ts");
+      const emittedDts = await fs.readFile(emittedFile, "utf-8");
+      const expectedDts = path.join(dir, testCase.expectedDts);
+      const hasExpected = await exists(expectedDts);
+
+      if (!hasExpected || bless) {
+        await fs.writeFile(expectedDts, clean(emittedDts));
+      }
+
+      assert.strictEqual(clean(emittedDts), await fs.readFile(expectedDts, "utf-8"));
+
+      const sanity = spawnSync(
+        process.execPath,
+        [
+          tscBin,
+          "--noEmit",
+          "--target",
+          compilerOptions.target,
+          "--module",
+          compilerOptions.module,
+          "--moduleResolution",
+          compilerOptions.moduleResolution,
+          emittedFile,
+        ],
+        {
+          cwd: consumerDir,
+          encoding: "utf8",
+        },
+      );
+      const sanityDiagnostic = formatDiagnostic(`${sanity.stdout || ""}${sanity.stderr || ""}`, consumerDir);
+      assert.strictEqual(sanity.status, 0, sanityDiagnostic);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+}

--- a/tests/downstream.ts
+++ b/tests/downstream.ts
@@ -1,0 +1,31 @@
+import * as assert from "assert";
+import ts from "typescript";
+import { assertDownstream } from "./downstream-helpers.js";
+import { createBundle, isFixtureSupported, loadFixtureMeta, withInput } from "./fixture-helpers.js";
+import { forEachFixture, Harness } from "./utils.js";
+
+// Downstream consumer tests use --module NodeNext which requires TS 4.7+
+const [tsMajor, tsMinor] = ts.versionMajorMinor.split(".").map(Number) as [number, number];
+const supportsNodeNext = tsMajor > 4 || (tsMajor === 4 && tsMinor >= 7);
+
+export default (t: Harness) => {
+  forEachFixture("testcases", (name, dir) => {
+    t.test(`downstream/${name}`, async (bless) => {
+      const meta = await loadFixtureMeta(dir);
+
+      if (!meta.downstream?.length || meta.skip) {
+        return;
+      }
+
+      if (!isFixtureSupported(meta) || !supportsNodeNext) {
+        return;
+      }
+
+      const { output, warnings } = await createBundle(meta.options, { ...meta.rollupOptions, input: withInput(dir, meta.rollupOptions) });
+      if (meta.expectedWarnings) {
+        assert.deepStrictEqual([...warnings].sort(), [...meta.expectedWarnings].sort());
+      }
+      await assertDownstream(dir, output, meta.downstream, bless);
+    });
+  });
+};

--- a/tests/fixture-helpers.ts
+++ b/tests/fixture-helpers.ts
@@ -1,0 +1,113 @@
+import * as path from "path";
+import {
+  type InputOption,
+  type InputOptions,
+  rollup,
+  type RollupOptions,
+  VERSION as rollupVersionMajorMinorPatch,
+} from "rollup";
+import ts from "typescript";
+import dts, { type Options } from "../src/index.js";
+import type { DownstreamCase } from "./downstream-helpers.js";
+import { exists } from "./utils.js";
+
+export interface Meta {
+  options: Options;
+  rollupOptions: RollupOptions;
+  skip?: boolean;
+  expectedError?: string;
+  downstream?: DownstreamCase[];
+  expectedWarnings?: string[];
+  tsVersion?: string;
+  rollupVersion?: string;
+}
+
+export async function loadFixtureMeta(dir: string): Promise<Meta> {
+  const rollupOptions: InputOptions = {
+    input: (await exists(path.join(dir, "index.d.ts"))) ? "index.d.ts" : "index.ts",
+  };
+  const meta: Meta = {
+    options: {},
+    skip: false,
+    rollupOptions,
+  };
+
+  try {
+    Object.assign(meta, (await import("file://" + path.join(dir, "meta.js"))).default);
+    meta.rollupOptions = Object.assign(rollupOptions, meta.rollupOptions);
+  } catch {}
+
+  return meta;
+}
+
+export const isFixtureSupported = (meta: Meta) => {
+  if (meta.tsVersion) {
+    const [major, minor] = ts.versionMajorMinor.split(".").map(Number) as [number, number];
+    const [reqMajor, reqMinor] = meta.tsVersion.split(".").map(Number) as [number, number];
+    if (major < reqMajor || (major === reqMajor && minor < reqMinor)) {
+      return false;
+    }
+  }
+
+  if (meta.rollupVersion) {
+    const [major, minor, patch] = rollupVersionMajorMinorPatch.split(".").map(Number) as [number, number, number];
+    const [reqMajor, reqMinor, reqPatch] = meta.rollupVersion.split(".").map(Number) as [number, number, number];
+    if (
+      major < reqMajor ||
+      (major === reqMajor && minor < reqMinor) ||
+      (major === reqMajor && minor === reqMinor && patch < reqPatch)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export async function createBundle(options: Options, rollupOptions: RollupOptions) {
+  const warnings: string[] = [];
+  const bundle = await rollup({
+    ...rollupOptions,
+    plugins: [dts(options)],
+    onwarn(warning) {
+      // Only capture plugin warnings; ignore Rollup-internal warnings
+      // (e.g., UNKNOWN_OPTION from Rollup 3 not recognizing onLog)
+      if (typeof warning === "object" && warning.plugin) {
+        // Strip Rollup's `[plugin name] ` prefix for version-agnostic assertions
+        // (Rollup 4 adds the prefix, Rollup 3 does not)
+        const message = String(warning.message || warning).replace(/^\[plugin [^\]]+\] /, "");
+        warnings.push(message);
+      }
+    },
+  });
+
+  try {
+    const { output } = await bundle.generate({
+      ...rollupOptions.output,
+      format: "es",
+      sourcemap: false,
+      sourcemapExcludeSources: true,
+    });
+
+    return {
+      output,
+      warnings,
+    };
+  } finally {
+    await bundle.close();
+  }
+}
+
+export const withInput = (dir: string, { input }: InputOptions): InputOption => {
+  if (typeof input === "string") {
+    return path.join(dir, input);
+  }
+  if (Array.isArray(input)) {
+    return input.map((entry) => path.join(dir, entry));
+  }
+  const mapped: { [alias: string]: string } = {};
+  for (const alias of Object.keys(input!)) {
+    mapped[alias] = path.join(dir, input![alias]!);
+  }
+  return mapped;
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,3 +1,4 @@
+import downstream from "./downstream.js";
 import preprocess from "./preprocess.js";
 import sourcemap from "./sourcemap.js";
 import testcases from "./testcases.js";
@@ -8,6 +9,7 @@ main();
 async function main() {
   const harness = new Harness();
 
+  downstream(harness);
   preprocess(harness);
   sourcemap(harness);
   testcases(harness);

--- a/tests/testcases.ts
+++ b/tests/testcases.ts
@@ -1,97 +1,40 @@
 import * as assert from "assert";
 import fs from "fs/promises";
 import * as path from "path";
-import {
-  type InputOption,
-  type InputOptions,
-  rollup,
-  type RollupOptions,
-  type RollupOutput,
-  VERSION as rollupVersionMajorMinorPatch,
-} from "rollup";
-import ts from "typescript";
-import dts, { type Options } from "../src/index.js";
+import type { RollupOutput } from "rollup";
+import { createBundle, isFixtureSupported, loadFixtureMeta, type Meta, withInput } from "./fixture-helpers.js";
 import { exists, forEachFixture, Harness } from "./utils.js";
 
 export default (t: Harness) => {
   forEachFixture("testcases", (name, dir) => {
     t.test(`testcases/${name}`, async (bless) => {
-      const rollupOptions: InputOptions = {
-        input: (await exists(path.join(dir, "index.d.ts"))) ? "index.d.ts" : "index.ts",
-      };
-      const meta: Meta = {
-        options: {},
-        skip: false,
-        rollupOptions,
-      };
-      try {
-        Object.assign(meta, (await import("file://" + path.join(dir, "meta.js"))).default);
-        meta.rollupOptions = Object.assign(rollupOptions, meta.rollupOptions);
-      } catch {}
+      const meta = await loadFixtureMeta(dir);
 
-      if (meta.tsVersion) {
-        const [major, minor] = ts.versionMajorMinor.split(".").map(Number) as [number, number];
-        const [reqMajor, reqMinor] = meta.tsVersion.split(".").map(Number) as [number, number];
-        if (major < reqMajor || (major === reqMajor && minor < reqMinor)) {
-          // skip unsupported version
-          return;
-        }
-      }
-      if (meta.rollupVersion) {
-        const [major, minor, patch] = rollupVersionMajorMinorPatch.split(".").map(Number) as [number, number, number];
-        const [reqMajor, reqMinor, reqPatch] = meta.rollupVersion.split(".").map(Number) as [number, number, number];
-        if (
-          major < reqMajor ||
-          (major === reqMajor && minor < reqMinor) ||
-          (major === reqMajor && minor === reqMinor && patch < reqPatch)
-        ) {
-          // skip unsupported version
-          return;
-        }
+      if (meta.skip || !isFixtureSupported(meta)) {
+        return;
       }
 
-      if (!meta.skip) {
-        return assertTestcase(dir, meta, bless);
-      }
+      return assertTestcase(dir, meta, bless);
     });
   });
 };
 
-export interface Meta {
-  options: Options;
-  rollupOptions: RollupOptions;
-  skip?: boolean;
-  expectedError?: string;
-  tsVersion?: string;
-  rollupVersion?: string;
-}
-
-async function createBundle(options: Options, rollupOptions: RollupOptions) {
-  const bundle = await rollup({
-    ...rollupOptions,
-    plugins: [dts(options)],
-    onwarn() {},
+/**
+ * Replace Rollup's content hashes in chunk filenames with stable sequential
+ * placeholders so snapshot assertions work across Rollup versions.
+ *
+ * e.g. `shared.d-BwjD5eaf.js` → `shared.d-HASH1.js`
+ */
+function normalizeChunkHashes(code: string): string {
+  const seen = new Map<string, string>();
+  return code.replace(/-[A-Za-z0-9_-]{8}\./g, (match) => {
+    let placeholder = seen.get(match);
+    if (!placeholder) {
+      placeholder = `-HASH${seen.size + 1}.`;
+      seen.set(match, placeholder);
+    }
+    return placeholder;
   });
-  return bundle.generate({
-    ...rollupOptions.output,
-    format: "es",
-    sourcemap: false,
-    sourcemapExcludeSources: true,
-  });
-}
-
-function withInput(dir: string, { input }: InputOptions): InputOption {
-  if (typeof input === "string") {
-    return path.join(dir, input);
-  }
-  if (Array.isArray(input)) {
-    return input.map((input) => path.join(dir, input));
-  }
-  const mapped: { [alias: string]: string } = {};
-  for (const alias of Object.keys(input!)) {
-    mapped[alias] = path.join(dir, input![alias]!);
-  }
-  return mapped;
 }
 
 function clean(code: string = "") {
@@ -104,15 +47,16 @@ function clean(code: string = "") {
 }
 
 async function assertTestcase(dir: string, meta: Meta, bless: boolean) {
-  const { expectedError, options, rollupOptions } = meta;
+  const { expectedError, expectedWarnings, options, rollupOptions } = meta;
 
   const input = withInput(dir, rollupOptions);
   const creator = createBundle(options, { ...rollupOptions, input });
   let output!: RollupOutput["output"];
+  let warnings!: string[];
   let error!: Error;
 
   try {
-    ({ output } = await creator);
+    ({ output, warnings } = await creator);
   } catch (e) {
     error = e as any;
     if (!expectedError) {
@@ -122,6 +66,10 @@ async function assertTestcase(dir: string, meta: Meta, bless: boolean) {
   if (expectedError) {
     assert.strictEqual(error.message, expectedError);
     return;
+  }
+
+  if (expectedWarnings) {
+    assert.deepStrictEqual([...warnings].sort(), [...expectedWarnings].sort());
   }
 
   const hasMultipleOutputs = output.length > 1;
@@ -144,7 +92,7 @@ async function assertTestcase(dir: string, meta: Meta, bless: boolean) {
   }
 
   const expectedCode = await fs.readFile(expectedDts, "utf-8");
-  assert.strictEqual(code, expectedCode);
+  assert.strictEqual(normalizeChunkHashes(code), normalizeChunkHashes(expectedCode));
   // expect(String(map)).toEqual(await fsExtra.readFile(expectedMap, "utf-8"));
 
   if (hasExpected && !hasMultipleOutputs) {
@@ -153,6 +101,7 @@ async function assertTestcase(dir: string, meta: Meta, bless: boolean) {
     } = await createBundle(options, { ...rollupOptions, input: expectedDts });
 
     // typescript `.d.ts` output compresses whitespace, so make sure we ignore that
-    assert.strictEqual(clean(sanityCheck.code), expectedCode);
+    assert.strictEqual(normalizeChunkHashes(clean(sanityCheck.code)), normalizeChunkHashes(expectedCode));
   }
+
 }

--- a/tests/testcases/downstream-harness-smoke/consumer.ts
+++ b/tests/testcases/downstream-harness-smoke/consumer.ts
@@ -1,0 +1,3 @@
+import { foo } from "lib/index";
+
+export const foo2 = foo;

--- a/tests/testcases/downstream-harness-smoke/expected-consumer.d.ts
+++ b/tests/testcases/downstream-harness-smoke/expected-consumer.d.ts
@@ -1,0 +1,1 @@
+export declare const foo2: import("lib/index").Foo;

--- a/tests/testcases/downstream-harness-smoke/expected.d.ts
+++ b/tests/testcases/downstream-harness-smoke/expected.d.ts
@@ -1,0 +1,6 @@
+interface Foo {
+  value: string;
+}
+declare const foo: Foo;
+export { foo };
+export type { Foo };

--- a/tests/testcases/downstream-harness-smoke/index.d.ts
+++ b/tests/testcases/downstream-harness-smoke/index.d.ts
@@ -1,0 +1,5 @@
+export interface Foo {
+  value: string;
+}
+
+export declare const foo: Foo;

--- a/tests/testcases/downstream-harness-smoke/meta.js
+++ b/tests/testcases/downstream-harness-smoke/meta.js
@@ -1,0 +1,12 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  downstream: [
+    {
+      consumer: "consumer.ts",
+      expectedDts: "expected-consumer.d.ts",
+    },
+  ],
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/shared-chunk-all-reexport/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-all-reexport/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-all-reexport/consumer-entry-b.ts
+++ b/tests/testcases/shared-chunk-all-reexport/consumer-entry-b.ts
@@ -1,0 +1,3 @@
+import { accept } from "lib/entry-b";
+
+export const fn = accept;

--- a/tests/testcases/shared-chunk-all-reexport/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared";
+export declare const a: Shared;
+export type { Shared };

--- a/tests/testcases/shared-chunk-all-reexport/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/entry-b.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared";
+export declare function accept(s: Shared): void;
+export type { Shared };

--- a/tests/testcases/shared-chunk-all-reexport/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-a").Shared;

--- a/tests/testcases/shared-chunk-all-reexport/expected-consumer-entry-b.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/expected-consumer-entry-b.d.ts
@@ -1,0 +1,2 @@
+import { accept } from "lib/entry-b";
+export declare const fn: typeof accept;

--- a/tests/testcases/shared-chunk-all-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/expected.d.ts
@@ -1,0 +1,14 @@
+// entry-a.d.ts
+import { S as Shared } from './shared.d-BwjD5eaf.js';
+declare const a: Shared;
+export { Shared, a };
+// entry-b.d.ts
+import { S as Shared } from './shared.d-BwjD5eaf.js';
+declare function accept(s: Shared): void;
+export { Shared, accept };
+// shared.d-BwjD5eaf.d.ts
+declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+export { Shared as S };

--- a/tests/testcases/shared-chunk-all-reexport/meta.js
+++ b/tests/testcases/shared-chunk-all-reexport/meta.js
@@ -1,0 +1,20 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-b.ts",
+      expectedDts: "expected-consumer-entry-b.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-all-reexport/shared.d.ts
+++ b/tests/testcases/shared-chunk-all-reexport/shared.d.ts
@@ -1,0 +1,4 @@
+export declare class Shared {
+  private _id: string;
+  get id(): string;
+}

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/consumer-entry-h.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/consumer-entry-h.ts
@@ -1,0 +1,3 @@
+import { h } from "lib/entry-a";
+
+export const h2 = h;

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/entry-a.d.ts
@@ -1,0 +1,5 @@
+import { Hidden, Shared } from "./shared.js";
+
+export declare const a: Shared;
+export declare const h: Hidden;
+export type { Shared as PublicShared };

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/entry-b.d.ts
@@ -1,0 +1,1 @@
+export type { Shared } from "./shared.js";

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-a").PublicShared;

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected.d.ts
@@ -1,0 +1,16 @@
+// entry-a.d.ts
+import { S as Shared, H as Hidden } from './entry-b.d-BU7AAKVR.js';
+declare const a: Shared;
+declare const h: Hidden;
+export { Shared as PublicShared, a, h };
+// entry-b.d.ts
+export { S as Shared } from './entry-b.d-BU7AAKVR.js';
+// entry-b.d-BU7AAKVR.d.ts
+declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+declare class Hidden {
+  private _hidden: string;
+}
+export { Hidden as H, Shared as S };

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/meta.js
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/meta.js
@@ -1,0 +1,22 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [
+    'Entry "entry-a.d.ts" still references private shared type exports with no public re-export: Hidden. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+  ],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-h.ts",
+      expectedErrorIncludes: ["error TS2742"],
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/shared.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/shared.d.ts
@@ -1,0 +1,8 @@
+export declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+
+export declare class Hidden {
+  private _hidden: string;
+}

--- a/tests/testcases/shared-chunk-export-star-host/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-export-star-host/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-export-star-host/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-export-star-host/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-export-star-host/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-export-star-host/entry-b.d.ts
@@ -1,0 +1,1 @@
+export * from "./shared.js";

--- a/tests/testcases/shared-chunk-export-star-host/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-export-star-host/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-export-star-host/expected.d.ts
+++ b/tests/testcases/shared-chunk-export-star-host/expected.d.ts
@@ -1,0 +1,10 @@
+// entry-a.d.ts
+import { Shared } from './entry-b.js';
+declare const a: Shared;
+export { a };
+// entry-b.d.ts
+declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+export { Shared };

--- a/tests/testcases/shared-chunk-export-star-host/meta.js
+++ b/tests/testcases/shared-chunk-export-star-host/meta.js
@@ -1,0 +1,16 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-export-star-host/shared.d.ts
+++ b/tests/testcases/shared-chunk-export-star-host/shared.d.ts
@@ -1,0 +1,4 @@
+export declare class Shared {
+  private _id: string;
+  get id(): string;
+}

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/consumer-entry-b.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/consumer-entry-b.ts
@@ -1,0 +1,3 @@
+import { b } from "lib/entry-b";
+
+export const b2 = b;

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/entry-b.d.ts
@@ -1,0 +1,4 @@
+import { Shared } from "./shared.js";
+
+export declare const b: Shared;
+export type { Shared };

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/expected-consumer-entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/expected-consumer-entry-b.d.ts
@@ -1,0 +1,1 @@
+export declare const b2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/expected.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/expected.d.ts
@@ -1,0 +1,13 @@
+// entry-a.d.cts
+import { Shared } from './entry-b.cjs';
+declare const a: Shared;
+export { a };
+// entry-b.d.cts
+import { S as Shared } from './shared.d-En--5LAw.cjs';
+declare const b: Shared;
+export { Shared, b };
+// shared.d-En--5LAw.d.cts
+declare class Shared {
+  value: string;
+}
+export { Shared as S };

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/meta.js
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/meta.js
@@ -1,0 +1,24 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-b.ts",
+      expectedDts: "expected-consumer-entry-b.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+    output: {
+      entryFileNames: "[name].d.cts",
+      chunkFileNames: "[name]-[hash].d.cts",
+    },
+  },
+  rollupVersion: "4.44.0",
+};

--- a/tests/testcases/shared-chunk-last-entry-reexport-cts/shared.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-cts/shared.d.ts
@@ -1,0 +1,3 @@
+export declare class Shared {
+  value: string;
+}

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/consumer-entry-b.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/consumer-entry-b.ts
@@ -1,0 +1,3 @@
+import { b } from "lib/entry-b";
+
+export const b2 = b;

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/entry-b.d.ts
@@ -1,0 +1,4 @@
+import { Shared } from "./shared.js";
+
+export declare const b: Shared;
+export type { Shared };

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/expected-consumer-entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/expected-consumer-entry-b.d.ts
@@ -1,0 +1,1 @@
+export declare const b2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/expected.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/expected.d.ts
@@ -1,0 +1,13 @@
+// entry-a.d.mts
+import { Shared } from './entry-b.mjs';
+declare const a: Shared;
+export { a };
+// entry-b.d.mts
+import { S as Shared } from './shared.d-En--5LAw.mjs';
+declare const b: Shared;
+export { Shared, b };
+// shared.d-En--5LAw.d.mts
+declare class Shared {
+  value: string;
+}
+export { Shared as S };

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/meta.js
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/meta.js
@@ -1,0 +1,24 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-b.ts",
+      expectedDts: "expected-consumer-entry-b.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+    output: {
+      entryFileNames: "[name].d.mts",
+      chunkFileNames: "[name]-[hash].d.mts",
+    },
+  },
+  rollupVersion: "4.44.0",
+};

--- a/tests/testcases/shared-chunk-last-entry-reexport-mts/shared.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport-mts/shared.d.ts
@@ -1,0 +1,3 @@
+export declare class Shared {
+  value: string;
+}

--- a/tests/testcases/shared-chunk-last-entry-reexport/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-last-entry-reexport/consumer-entry-b.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/consumer-entry-b.ts
@@ -1,0 +1,3 @@
+import { b } from "lib/entry-b";
+
+export const b2 = b;

--- a/tests/testcases/shared-chunk-last-entry-reexport/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/entry-a.d.ts
@@ -1,0 +1,2 @@
+import { Shared } from "./shared";
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/entry-b.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared";
+export declare const b: Shared;
+export type { Shared };

--- a/tests/testcases/shared-chunk-last-entry-reexport/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport/expected-consumer-entry-b.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/expected-consumer-entry-b.d.ts
@@ -1,0 +1,1 @@
+export declare const b2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-last-entry-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/expected.d.ts
@@ -1,0 +1,13 @@
+// entry-a.d.ts
+import { Shared } from './entry-b.js';
+declare const a: Shared;
+export { a };
+// entry-b.d.ts
+import { S as Shared } from './shared.d-En--5LAw.js';
+declare const b: Shared;
+export { Shared, b };
+// shared.d-En--5LAw.d.ts
+declare class Shared {
+  value: string;
+}
+export { Shared as S };

--- a/tests/testcases/shared-chunk-last-entry-reexport/meta.js
+++ b/tests/testcases/shared-chunk-last-entry-reexport/meta.js
@@ -1,0 +1,20 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-b.ts",
+      expectedDts: "expected-consumer-entry-b.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-last-entry-reexport/shared.d.ts
+++ b/tests/testcases/shared-chunk-last-entry-reexport/shared.d.ts
@@ -1,0 +1,3 @@
+export declare class Shared {
+  value: string;
+}

--- a/tests/testcases/shared-chunk-mixed-visibility/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-mixed-visibility/consumer-entry-h.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/consumer-entry-h.ts
@@ -1,0 +1,3 @@
+import { h } from "lib/entry-a";
+
+export const h2 = h;

--- a/tests/testcases/shared-chunk-mixed-visibility/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/entry-a.d.ts
@@ -1,0 +1,4 @@
+import { Hidden, Shared } from "./shared.js";
+
+export declare const a: Shared;
+export declare const h: Hidden;

--- a/tests/testcases/shared-chunk-mixed-visibility/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/entry-b.d.ts
@@ -1,0 +1,1 @@
+export type { Shared } from "./shared.js";

--- a/tests/testcases/shared-chunk-mixed-visibility/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-mixed-visibility/expected.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/expected.d.ts
@@ -1,0 +1,16 @@
+// entry-a.d.ts
+import { H as Hidden } from './entry-b.d-2AtcXeZ_.js';
+import { Shared } from './entry-b.js';
+declare const a: Shared;
+declare const h: Hidden;
+export { a, h };
+// entry-b.d.ts
+export { S as Shared } from './entry-b.d-2AtcXeZ_.js';
+// entry-b.d-2AtcXeZ_.d.ts
+declare class Shared {
+  private _shared: string;
+}
+declare class Hidden {
+  private _hidden: string;
+}
+export { Hidden as H, Shared as S };

--- a/tests/testcases/shared-chunk-mixed-visibility/meta.js
+++ b/tests/testcases/shared-chunk-mixed-visibility/meta.js
@@ -1,0 +1,22 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [
+    'Entry "entry-a.d.ts" still references private shared type exports with no public re-export: Hidden. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+  ],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+    {
+      consumer: "consumer-entry-h.ts",
+      expectedErrorIncludes: ["error TS2742"],
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-mixed-visibility/shared.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/shared.d.ts
@@ -1,0 +1,7 @@
+export declare class Shared {
+  private _shared: string;
+}
+
+export declare class Hidden {
+  private _hidden: string;
+}

--- a/tests/testcases/shared-chunk-multi-host/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-multi-host/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-multi-host/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-multi-host/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/entry-b.d.ts
@@ -1,0 +1,1 @@
+export type { Shared } from "./shared.js";

--- a/tests/testcases/shared-chunk-multi-host/entry-c.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/entry-c.d.ts
@@ -1,0 +1,1 @@
+export type { Shared } from "./shared.js";

--- a/tests/testcases/shared-chunk-multi-host/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").Shared;

--- a/tests/testcases/shared-chunk-multi-host/expected.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/expected.d.ts
@@ -1,0 +1,12 @@
+// entry-a.d.ts
+import { Shared } from './entry-b.js';
+declare const a: Shared;
+export { a };
+// entry-b.d.ts
+declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+export { Shared };
+// entry-c.d.ts
+export { Shared } from './entry-b.js';

--- a/tests/testcases/shared-chunk-multi-host/meta.js
+++ b/tests/testcases/shared-chunk-multi-host/meta.js
@@ -1,0 +1,16 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts", "entry-c.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-multi-host/shared.d.ts
+++ b/tests/testcases/shared-chunk-multi-host/shared.d.ts
@@ -1,0 +1,4 @@
+export declare class Shared {
+  private _id: string;
+  get id(): string;
+}

--- a/tests/testcases/shared-chunk-no-reexport/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-no-reexport/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-no-reexport/consumer-entry-b.ts
+++ b/tests/testcases/shared-chunk-no-reexport/consumer-entry-b.ts
@@ -1,0 +1,3 @@
+import { b } from "lib/entry-b";
+
+export const b2 = b;

--- a/tests/testcases/shared-chunk-no-reexport/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-no-reexport/entry-a.d.ts
@@ -1,0 +1,2 @@
+import { Shared } from "./shared";
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-no-reexport/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-no-reexport/entry-b.d.ts
@@ -1,0 +1,2 @@
+import { Shared } from "./shared";
+export declare const b: Shared;

--- a/tests/testcases/shared-chunk-no-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-no-reexport/expected.d.ts
@@ -1,0 +1,13 @@
+// entry-a.d.ts
+import { S as Shared } from './shared.d-En--5LAw.js';
+declare const a: Shared;
+export { a };
+// entry-b.d.ts
+import { S as Shared } from './shared.d-En--5LAw.js';
+declare const b: Shared;
+export { b };
+// shared.d-En--5LAw.d.ts
+declare class Shared {
+  value: string;
+}
+export { Shared as S };

--- a/tests/testcases/shared-chunk-no-reexport/meta.js
+++ b/tests/testcases/shared-chunk-no-reexport/meta.js
@@ -1,0 +1,22 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [
+    'Entry "entry-a.d.ts" still references private shared type exports with no public re-export: Shared. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+    'Entry "entry-b.d.ts" still references private shared type exports with no public re-export: Shared. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+  ],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedErrorIncludes: ["error TS2742", "shared.d-"],
+    },
+    {
+      consumer: "consumer-entry-b.ts",
+      expectedErrorIncludes: ["error TS2742", "shared.d-"],
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+};

--- a/tests/testcases/shared-chunk-no-reexport/shared.d.ts
+++ b/tests/testcases/shared-chunk-no-reexport/shared.d.ts
@@ -1,0 +1,3 @@
+export declare class Shared {
+  value: string;
+}

--- a/tests/testcases/shared-chunk-renamed-host-reexport/consumer-entry-a.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/consumer-entry-a.ts
@@ -1,0 +1,3 @@
+import { a } from "lib/entry-a";
+
+export const a2 = a;

--- a/tests/testcases/shared-chunk-renamed-host-reexport/entry-a.d.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/entry-a.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export declare const a: Shared;

--- a/tests/testcases/shared-chunk-renamed-host-reexport/entry-b.d.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/entry-b.d.ts
@@ -1,0 +1,3 @@
+import { Shared } from "./shared.js";
+
+export type { Shared as HostShared };

--- a/tests/testcases/shared-chunk-renamed-host-reexport/expected-consumer-entry-a.d.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/expected-consumer-entry-a.d.ts
@@ -1,0 +1,1 @@
+export declare const a2: import("lib/entry-b").HostShared;

--- a/tests/testcases/shared-chunk-renamed-host-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/expected.d.ts
@@ -1,0 +1,10 @@
+// entry-a.d.ts
+import { HostShared as Shared } from './entry-b.js';
+declare const a: Shared;
+export { a };
+// entry-b.d.ts
+declare class Shared {
+  private _id: string;
+  get id(): string;
+}
+export { Shared as HostShared };

--- a/tests/testcases/shared-chunk-renamed-host-reexport/meta.js
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/meta.js
@@ -1,0 +1,16 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  expectedWarnings: [],
+  downstream: [
+    {
+      consumer: "consumer-entry-a.ts",
+      expectedDts: "expected-consumer-entry-a.d.ts",
+    },
+  ],
+  rollupOptions: {
+    input: ["entry-a.d.ts", "entry-b.d.ts"],
+  },
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/shared-chunk-renamed-host-reexport/shared.d.ts
+++ b/tests/testcases/shared-chunk-renamed-host-reexport/shared.d.ts
@@ -1,0 +1,4 @@
+export declare class Shared {
+  private _id: string;
+  get id(): string;
+}


### PR DESCRIPTION
## Problem
`TS2742` shows up downstream when TypeScript has to name a public type through a private declaration path.

A small example looks like this:

```ts
// entry-a.d.ts
import { Shared } from "./shared.js";
export declare const a: Shared;

// entry-b.d.ts
export type { Shared } from "./shared.js";
```

A consumer can write:

```ts
import { a } from "lib/entry-a";
export const a2 = a;
```

and still get `TS2742`, because TypeScript does not go looking for some other public entry that happens to re-export `Shared`. It keeps following the declaration path it already has, which still points at the private shared chunk.

That is the case this PR is about. It is not a blanket "shared chunks are broken" issue. Some shapes are already portable, and some shapes are package-author problems that the plugin should not try to auto-fix.

For related context:
- [TypeScript issue: TS2742 with sibling re-export paths](https://github.com/microsoft/TypeScript/issues/60913)
- [TypeScript issue: TS2742 error-message DX](https://github.com/microsoft/TypeScript/issues/53764)

## What This PR Changes
This PR adds a narrow rewrite for the real plugin-side case.

When an entry leaks a type through a private shared chunk, and another public entry already re-exports that same type, the plugin rewrites the leaking entry to import through the public host entry instead.

So this:

```ts
// before
import { Shared } from "./shared.js";
export declare const a: Shared;
```

becomes this:

```ts
// after
import { Shared } from "./entry-b.js";
export declare const a: Shared;
```

That gives downstream TypeScript a public naming path such as:

```ts
export declare const a2: import("lib/entry-b").Shared;
```

The PR also adds a downstream consumer test harness so these cases are tested the way users actually hit them: by compiling a fake consumer package with `tsc --declaration`, then sanity-checking the emitted `.d.ts` again.

On top of the original repro, the suite now covers renamed host re-exports, `export *` hosts, multi-host selection, and mixed symbol visibility. For the `no-reexport` case, the plugin now emits a warning instead of silently leaving users with an unexplained downstream failure.

## Why This Solution
This is the smallest fix that improves real user experience without changing package API.

It works because it reuses a public path that already exists. It does not invent exports, merge hidden symbols into entry points, or flatten every shared chunk into an entry.

That matters for two reasons.

First, not every shared chunk is a bug. If an entry already exports the shared type publicly, downstream TypeScript can often name through that entry just fine. Rewriting everything would be unnecessary churn.

Second, when no public export exists, the plugin should not guess what the package API ought to be. Creating new exports would be a behavior change for the library, not just a portability fix.

## What Else We Considered
We considered treating every shared chunk as a plugin bug and always merging or rerouting it into an entry. The experiments did not support that. Some cases are already portable today, so that approach would solve the wrong problem and change more output than necessary.

We also considered auto-fixing the `no-reexport` case. That was rejected because it would create new public API surface. In that shape, the right move is guidance, not mutation, so this PR adds a warning instead.

We also verified that a sibling re-export alone is not enough. TypeScript does not discover it by itself; the declaration graph has to be rewritten explicitly. That is why the fix happens in the plugin output rather than in test expectations or docs alone.

## Testing
`npm test`