### PR TITLE
fix: avoid duplicate type modifier in exports

### DIFF
--- a/src/transform/TypeOnlyFixer.ts
+++ b/src/transform/TypeOnlyFixer.ts
@@ -145,7 +145,7 @@ export class TypeOnlyFixer {
           : this.isTypeOnly(name);
         if(isType) {
           // export { A as B } from 'a';   ->   export type { A as B } from 'a';
-          typeNames.push(element.getText())
+          typeNames.push(getExportSpecifierBinding(element))
         } else {
           // export { A as B };   ->   export { A as B };
           valueNames.push(element.getText())
@@ -277,6 +277,14 @@ export class TypeOnlyFixer {
 function getNodeIndent(node: ts.Node) {
   const match = node.getFullText().match(/^(?:\n*)([ ]*)/)
   return ' '.repeat(match?.[1]?.length || 0);
+}
+
+function getExportSpecifierBinding(element: ts.ExportSpecifier) {
+  if(element.propertyName) {
+    return `${element.propertyName.getText()} as ${element.name.getText()}`;
+  }
+
+  return element.name.getText();
 }
 
 let typeOnlyHintIds = 0;

--- a/tests/testcases/namespace-type-export-specifier/expected.d.ts
+++ b/tests/testcases/namespace-type-export-specifier/expected.d.ts
@@ -1,0 +1,7 @@
+type T = { one: 1 };
+type U = { two: 2 };
+declare namespace component {
+  export type { T };
+  export type { U as V };
+}
+export { component };

--- a/tests/testcases/namespace-type-export-specifier/index.d.ts
+++ b/tests/testcases/namespace-type-export-specifier/index.d.ts
@@ -1,0 +1,9 @@
+type T = { one: 1 };
+type U = { two: 2 };
+
+declare namespace component {
+  export { type T };
+  export { type U as V };
+}
+
+export { component };


### PR DESCRIPTION
## Summary
- Fixes a rewrite bug where namespace exports like `export { type T }` became invalid `export type { type T }`.
- When grouping type-only exports under `export type { ... }`, the fixer now prints only the export binding, e.g. `T` or `U as V`.
- Adds a regression fixture for plain and aliased namespace type exports.

## Test
- `npm test -- namespace-type-export-specifier`
- `npm test`