### PR TITLE
fix: correctly resolve string literals in export specifiers

### DIFF
--- a/src/transform/astHelpers.ts
+++ b/src/transform/astHelpers.ts
@@ -41,7 +41,7 @@ export function createIdentifier(node: ts.Identifier | ts.StringLiteral): ESTree
   return withStartEnd(
     {
       type: "Identifier",
-      name: node.getText(),
+      name: node.text,
     },
     node,
   );

--- a/tests/testcases/string-literal-export-names/expected.d.ts
+++ b/tests/testcases/string-literal-export-names/expected.d.ts
@@ -1,0 +1,9 @@
+declare const a: "a";
+declare const b: "b";
+declare const c: "c";
+declare class Test {
+  [a]: string;
+  [b]: string;
+  [c]: string;
+}
+export { Test };

--- a/tests/testcases/string-literal-export-names/index.d.ts
+++ b/tests/testcases/string-literal-export-names/index.d.ts
@@ -1,0 +1,10 @@
+import * as mod from "./mod";
+import { "c c" as cc } from "./mod";
+
+declare class Test {
+  [mod.aa]: string;
+  [mod.bb]: string;
+  [cc]: string;
+}
+
+export { Test };

--- a/tests/testcases/string-literal-export-names/meta.js
+++ b/tests/testcases/string-literal-export-names/meta.js
@@ -1,0 +1,7 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  tsVersion: "5.6",
+  options: {},
+  rollupOptions: {},
+};

--- a/tests/testcases/string-literal-export-names/mod.d.ts
+++ b/tests/testcases/string-literal-export-names/mod.d.ts
@@ -1,0 +1,5 @@
+declare const a: "a";
+declare const b: "b";
+declare const c: "c";
+
+export { a as aa, b as "bb", c as "c c" };


### PR DESCRIPTION
### Description

Fixes the resolution of ES2022 string literal export names (e.g., `export { b as "bb" }`).

Currently, Rollup fails to link identifiers exported as string literals, resulting in missing exports and `[undefined]` properties in the bundled output. This occurs because `createIdentifier` uses `node.getText()`, which preserves the surrounding quotes for `ts.StringLiteral` nodes (e.g., `'"bb"'`), causing a mismatch in Rollup's linker.

Updating this to use `node.text` passes the unquoted identifier value, resolving the issue.

### Test Case

##### `mod.d.ts`

```ts
declare const a: "a";
declare const b: "b";
declare const c: "c";

export { a as aa, b as "bb", c as "c c" };
```

##### `index.d.ts`

```ts
import * as mod from "./mod";
import { "c c" as cc } from "./mod";

declare class Test {
  [mod.aa]: string;
  [mod.bb]: string;
  [cc]: string;
}

export { Test };
```

##### Actual Output (Failing):

```ts
declare const a: "a";
declare const c: "c";
declare class Test {
  [a]: string;
  [undefined]: string;
  [c]: string;
}
export { Test };
```

##### `expected.d.ts`

```ts
declare const a: "a";
declare const b: "b";
declare const c: "c";
declare class Test {
  [a]: string;
  [b]: string;
  [c]: string;
}
export { Test };
```