### PR TITLE
test: fix shared-chunk fixtures for TS 6 and sorted snapshot order

### DIFF
--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected.d.ts
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/expected.d.ts
@@ -3,8 +3,6 @@ import { S as Shared, H as Hidden } from './entry-b.d-BU7AAKVR.js';
 declare const a: Shared;
 declare const h: Hidden;
 export { Shared as PublicShared, a, h };
-// entry-b.d.ts
-export { S as Shared } from './entry-b.d-BU7AAKVR.js';
 // entry-b.d-BU7AAKVR.d.ts
 declare class Shared {
   private _id: string;
@@ -14,3 +12,5 @@ declare class Hidden {
   private _hidden: string;
 }
 export { Hidden as H, Shared as S };
+// entry-b.d.ts
+export { S as Shared } from './entry-b.d-BU7AAKVR.js';

--- a/tests/testcases/shared-chunk-current-entry-renamed-reexport/meta.js
+++ b/tests/testcases/shared-chunk-current-entry-renamed-reexport/meta.js
@@ -12,7 +12,7 @@ export default {
     },
     {
       consumer: "consumer-entry-h.ts",
-      expectedErrorIncludes: ["error TS2742"],
+      expectedErrorIncludes: ["cannot be named without a reference", "entry-b.d-"],
     },
   ],
   rollupOptions: {

--- a/tests/testcases/shared-chunk-mixed-visibility/expected.d.ts
+++ b/tests/testcases/shared-chunk-mixed-visibility/expected.d.ts
@@ -4,8 +4,6 @@ import { Shared } from './entry-b.js';
 declare const a: Shared;
 declare const h: Hidden;
 export { a, h };
-// entry-b.d.ts
-export { S as Shared } from './entry-b.d-2AtcXeZ_.js';
 // entry-b.d-2AtcXeZ_.d.ts
 declare class Shared {
   private _shared: string;
@@ -14,3 +12,5 @@ declare class Hidden {
   private _hidden: string;
 }
 export { Hidden as H, Shared as S };
+// entry-b.d.ts
+export { S as Shared } from './entry-b.d-2AtcXeZ_.js';

--- a/tests/testcases/shared-chunk-mixed-visibility/meta.js
+++ b/tests/testcases/shared-chunk-mixed-visibility/meta.js
@@ -12,7 +12,7 @@ export default {
     },
     {
       consumer: "consumer-entry-h.ts",
-      expectedErrorIncludes: ["error TS2742"],
+      expectedErrorIncludes: ["cannot be named without a reference", "entry-b.d-"],
     },
   ],
   rollupOptions: {

--- a/tests/testcases/shared-chunk-no-reexport/meta.js
+++ b/tests/testcases/shared-chunk-no-reexport/meta.js
@@ -9,11 +9,11 @@ export default {
   downstream: [
     {
       consumer: "consumer-entry-a.ts",
-      expectedErrorIncludes: ["error TS2742", "shared.d-"],
+      expectedErrorIncludes: ["cannot be named without a reference", "shared.d-"],
     },
     {
       consumer: "consumer-entry-b.ts",
-      expectedErrorIncludes: ["error TS2742", "shared.d-"],
+      expectedErrorIncludes: ["cannot be named without a reference", "shared.d-"],
     },
   ],
   rollupOptions: {


### PR DESCRIPTION
## Summary

Fixes the 5 test failures on `master` introduced by #383 (`1fb93d0`):

```
- downstream/shared-chunk-current-entry-renamed-reexport
- downstream/shared-chunk-mixed-visibility
- downstream/shared-chunk-no-reexport
- testcases/shared-chunk-current-entry-renamed-reexport
- testcases/shared-chunk-mixed-visibility
```

Fixes #390.

Test-only change — 5 fixture files, no harness or plugin source changes. The shared-chunk portability rewrite from #383 itself behaves correctly.

In short (full analysis in the [linked issue](https://github.com/Swatinem/rollup-plugin-dts/issues/390)): #383 was merged with checks that last ran in April, predating two master commits it semantically conflicts with — `227f7f8` (TS 6 emits TS2883 instead of the TS2742 the fixtures hard-code) and `9e999bc` (snapshot chunks are now sorted, flipping the order two `expected.d.ts` files were generated in).

## Changes

- **3 × `meta.js`** (`shared-chunk-no-reexport`, `shared-chunk-mixed-visibility`, `shared-chunk-current-entry-renamed-reexport`): the downstream assertions match the message text both diagnostic codes share — `"cannot be named without a reference"` — instead of the version-dependent error code (TS2742 on TS < 6, TS2883 on TS 6+). Each assertion stays anchored to the private shared chunk (`"shared.d-"` kept where it existed; `"entry-b.d-"` added to the two `consumer-entry-h` cases that previously checked only the code), so the tests still pin the error to the intended cause.
- **2 × `expected.d.ts`** (`shared-chunk-mixed-visibility`, `shared-chunk-current-entry-renamed-reexport`): regenerated under the sorted chunk order; content and hashes are otherwise unchanged.

### Why message text instead of error codes

- The code varies by TS version, and CI runs the suite under `typescript@beta` and minimum supported versions — an exact-code assertion breaks whenever TypeScript splits a diagnostic (which is exactly what TS 6 did). The shared message text has been stable since TS2742 was introduced and was deliberately reused in TS2883.
- Localization is not a concern: `tsc` only localizes when `--locale` is passed, which the harness never does.
- Matching text keeps the harness untouched — the alternative (accepting either code) requires widening `expectedErrorIncludes` to support alternatives.

## Testing

- `npm test` (build + full suite with `typescript@6.0.3`, `rollup@4.61.1`): ✅ all pass
- `npm install typescript@4.5 rollup@3.0 && node .build/tests/index.js` (CI's minimum-version leg): ✅ all pass (downstream tests are gated on TS ≥ 4.7 and skip, as designed)

## Notes for reviewers

- Another (harmless) regression from #383 surfaced while working on this, not addressed here — happy to file separately: all 42 `meta.js` fixtures annotate `@type {import('../../testcases').Meta}`, which used to resolve when `tests/testcases.ts` exported `Meta`. #383 moved `Meta` to `tests/fixture-helpers.ts` and left `testcases.ts` only *importing* it, so the annotation now resolves to nothing and fixtures get no editor type-checking. A one-line `export type { Meta } from "./fixture-helpers.js";` in `tests/testcases.ts` would restore it.
