### PR TITLE
ci: renovate CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm test
       # the codecov uploader only runs on unix,
@@ -29,8 +30,8 @@ jobs:
         continue-on-error: true
         run: bash <(curl -s https://codecov.io/bash) -t ${{secrets.CODECOV_TOKEN}} -B ${{ github.ref }} -f coverage/coverage-final.json
 
-      # test TypeScript 6 beta
-      - run: npm install typescript@beta
+      # test against TypeScript 5
+      - run: npm install typescript@5
       # aka `npm test` without the `pretest/build`
       - run: node .build/tests/index.js
 


### PR DESCRIPTION
## Summary

Small CI maintenance pass on `.github/workflows/ci.yml`:

- **Replace the `typescript@beta` compat run with `typescript@5`.** The beta step was there to smoke-test the then-unreleased TypeScript 6. Now that the pinned `typescript` devDependency *is* 6.x (`6.0.3`), that run just re-tests the same major as the main build. Meanwhile the **5.x** peer range — by far the most widely deployed major — was going completely untested. Pointing the step at `typescript@5` closes that gap.
- **Enable the built-in npm cache** on `actions/setup-node` (`cache: npm`) to speed up `npm ci`.

## Compat matrix, before vs. after

The peer range is `typescript@^4.5 || ^5.0 || ^6.0`. The extra install-and-retest steps at the bottom of the job exercise the edges of that range:

| Run              | Before        | After         |
| ---------------- | ------------- | ------------- |
| Main build/test  | TS 6.0.3      | TS 6.0.3      |
| Compat run       | TS beta (6.x) | **TS 5**      |
| Minimum-peer run | TS 4.5        | TS 4.5        |

## Deliberately out of scope

Noticed while reviewing, but **not** touched in this PR — happy to open follow-ups if wanted:

- **The Node matrix uses `latest`**, which resolves to the newest *released* Node line — currently **Node 26** (`v26.4.0`), a **Current** (non-LTS) release that won't reach Active LTS until ~October 2026. Both the test matrix and, more notably, the **codecov upload** (`if: ... matrix.node == 'latest'`) are pinned to it. Was that intentional, or should the coverage run be anchored to an LTS? No change made pending your call. Node 22/24 LTS lines are also currently untested (only `20` and `latest` run).
- **The minimum-peer run installs `rollup@3.0`**, but `peerDependencies` declares `rollup@^3.29.4` — so CI tests a version below the stated floor.

## Test plan

- CI green across the matrix.
- Confirm the `typescript@5` job resolves a 5.x version and the test suite passes against it.
