### PR TITLE
fix: harden relative `declare module` specifier rewriting

### DIFF
--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -51,6 +51,35 @@ function getAugmentedNames(body: ts.ModuleBlock) {
   return names;
 }
 
+/**
+ * Rewrites relative `declare module './x'` specifiers in bundled output so they point
+ * at the chunk containing the target module, keeping module augmentations reachable
+ * for consumers.
+ *
+ * preprocess resolves each relative specifier lexically against its source file's
+ * directory and stamps it with a `dts-resolved:` marker comment that rides through
+ * bundling attached to its declaration; this fixer decodes the marker, locates the
+ * target chunk via Rollup's chunk metadata, and overwrites the specifier with a
+ * chunk-relative path.
+ *
+ * The rewrite is skipped (original specifier kept + warning) when:
+ * - the target module is not part of any output chunk (orphaned files, asset-style
+ *   declarations) — a dangling specifier stays inert, while rewriting it would merge
+ *   the augmentation into the wrong module;
+ * - the target chunk does not export every augmented name unchanged (aliased
+ *   re-exports, `Foo` → `Foo$1` deconfliction) — augmentation matches by exported
+ *   name, so retargeting the specifier alone would desynchronize the two.
+ *
+ * Scope: only `./`/`../` specifiers are handled. Bare package names must be preserved
+ * verbatim, since consumers resolve them by name. tsconfig-paths aliases
+ * (`declare module "@/foo"`) are a known limitation — they cannot be resolved
+ * lexically. Supporting them would mean: in preprocess, for specifiers matching a
+ * `compilerOptions.paths` pattern (never for other bare names), resolve with
+ * `ts.resolveModuleName` against the declaring file's compiler options (synchronous,
+ * unlike the plugin context's `resolve`), skip `isExternalLibraryImport` results, and
+ * stamp the resolved file name; the extension probe below already bridges the
+ * remaining `.d.ts`-versus-`.ts` module id gap.
+ */
 export class ModuleDeclarationFixer {
   private code: MagicString;
   private sourcemap: boolean;

--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -105,9 +105,15 @@ export class ModuleDeclarationFixer {
     const jsExtMatch = absolutePath.match(/\.[cm]?js$/);
     const basePath = jsExtMatch ? absolutePath.slice(0, -jsExtMatch[0].length) : absolutePath;
 
-    // Try all file extensions that could appear as module IDs in Rollup's chunk metadata
-    const extensions = ["", ".d.ts", ".d.mts", ".d.cts", ".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"];
-    const possiblePaths = extensions.map((ext) => basePath + ext);
+    // Try all file extensions that could appear as module IDs in Rollup's chunk metadata,
+    // probing both the path itself and a directory index
+    const extensions = ["", ".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+    const possiblePaths: string[] = [];
+    for (const base of [basePath, `${basePath}/index`]) {
+      for (const ext of extensions) {
+        possiblePaths.push(base + ext);
+      }
+    }
 
     // Find which chunk contains this module
     for (const possiblePath of possiblePaths) {

--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -68,18 +68,25 @@ export class ModuleDeclarationFixer {
 
       const targetChunkName = this.getTargetChunkName(absolutePath);
 
-      const quote =
-        node.name.kind === ts.SyntaxKind.StringLiteral && "singleQuote" in node.name && node.name.singleQuote
-          ? "'"
-          : '"';
+      let specifier = node.name.getText();
+      if (targetChunkName === null) {
+        // Keep the original specifier; consumers resolve it relative to the emitted
+        // chunk, where it will typically dangle (a no-op augmentation) rather than
+        // merge into the wrong module the way a current-chunk rewrite would
+        this.warn(
+          `declare module ${specifier} (${absolutePath}) could not be resolved to any output chunk, keeping the original specifier`,
+        );
+      } else {
+        const quote =
+          node.name.kind === ts.SyntaxKind.StringLiteral && "singleQuote" in node.name && node.name.singleQuote
+            ? "'"
+            : '"';
+        specifier = `${quote}${targetChunkName}${quote}`;
+      }
 
       const cleanedBetween = stripResolvedModuleComment(textBetween);
 
-      this.code.overwrite(
-        node.name.getStart(),
-        node.body.getStart(),
-        `${quote}${targetChunkName}${quote}${cleanedBetween}`,
-      );
+      this.code.overwrite(node.name.getStart(), node.body.getStart(), specifier + cleanedBetween);
       modified = true;
     }
 
@@ -91,8 +98,9 @@ export class ModuleDeclarationFixer {
 
   /**
    * Get the output chunk name for an absolute module path.
+   * Returns null when the module is not part of any output chunk.
    */
-  private getTargetChunkName(absolutePath: string): string {
+  private getTargetChunkName(absolutePath: string): string | null {
     // Detect JS extension from the resolved path (present when the source uses ESM-style specifiers)
     const jsExtMatch = absolutePath.match(/\.[cm]?js$/);
     const basePath = jsExtMatch ? absolutePath.slice(0, -jsExtMatch[0].length) : absolutePath;
@@ -109,12 +117,7 @@ export class ModuleDeclarationFixer {
       }
     }
 
-    // Module is not found in any chunk, keep the current chunk name as a fallback
-    this.warn(
-      `declare module "${absolutePath}" could not be resolved to any output chunk, falling back to current chunk "${this.chunkFileName}"`,
-    );
-
-    return this.formatChunkReference(this.chunkFileName, jsExtMatch?.[0]);
+    return null;
   }
 
   /**

--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -27,12 +27,37 @@ function normalizePath(p: string) {
   return p.split("\\").join("/");
 }
 
+/** Collect the names declared at the top level of an augmentation body. */
+function getAugmentedNames(body: ts.ModuleBlock) {
+  const names: string[] = [];
+  for (const statement of body.statements) {
+    if (
+      (ts.isInterfaceDeclaration(statement) ||
+        ts.isClassDeclaration(statement) ||
+        ts.isFunctionDeclaration(statement) ||
+        ts.isEnumDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement)) &&
+      statement.name
+    ) {
+      names.push(statement.name.text);
+    } else if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          names.push(declaration.name.text);
+        }
+      }
+    }
+  }
+  return names;
+}
+
 export class ModuleDeclarationFixer {
   private code: MagicString;
   private sourcemap: boolean;
   private source: ts.SourceFile;
   private chunkFileName: string;
   private moduleToChunk: Map<string, string>;
+  private chunks: Record<string, RenderedChunk>;
   private warn: (message: string) => void;
 
   constructor(
@@ -40,6 +65,7 @@ export class ModuleDeclarationFixer {
     code: MagicString,
     sourcemap: boolean,
     moduleToChunk: Map<string, string>,
+    chunks: Record<string, RenderedChunk>,
     warn: (message: string) => void,
   ) {
     this.code = code;
@@ -47,6 +73,7 @@ export class ModuleDeclarationFixer {
     this.source = parse(chunk.fileName, code.toString());
     this.chunkFileName = chunk.fileName;
     this.moduleToChunk = moduleToChunk;
+    this.chunks = chunks;
     this.warn = warn;
   }
 
@@ -66,22 +93,29 @@ export class ModuleDeclarationFixer {
         continue;
       }
 
-      const targetChunkName = this.getTargetChunkName(absolutePath);
+      const target = this.findTargetChunk(absolutePath);
 
       let specifier = node.name.getText();
-      if (targetChunkName === null) {
+      if (target === null) {
         // Keep the original specifier; consumers resolve it relative to the emitted
         // chunk, where it will typically dangle (a no-op augmentation) rather than
         // merge into the wrong module the way a current-chunk rewrite would
         this.warn(
           `declare module ${specifier} (${absolutePath}) could not be resolved to any output chunk, keeping the original specifier`,
         );
+      } else if (!this.augmentationApplies(getAugmentedNames(node.body), target.moduleId, target.chunkFileName)) {
+        // Module augmentation matches by the target module's exported names; when the
+        // chunk renamed, dropped, or ambiguously exports an augmented name, retargeting
+        // the specifier would merge the augmentation into the wrong declaration
+        this.warn(
+          `declare module ${specifier} (${absolutePath}) augments names that the target chunk does not export unchanged, keeping the original specifier`,
+        );
       } else {
         const quote =
           node.name.kind === ts.SyntaxKind.StringLiteral && "singleQuote" in node.name && node.name.singleQuote
             ? "'"
             : '"';
-        specifier = `${quote}${targetChunkName}${quote}`;
+        specifier = `${quote}${this.formatChunkReference(target.chunkFileName, target.jsExt)}${quote}`;
       }
 
       const cleanedBetween = stripResolvedModuleComment(textBetween);
@@ -97,10 +131,10 @@ export class ModuleDeclarationFixer {
   }
 
   /**
-   * Get the output chunk name for an absolute module path.
+   * Find the output chunk containing the module at an absolute path.
    * Returns null when the module is not part of any output chunk.
    */
-  private getTargetChunkName(absolutePath: string): string | null {
+  private findTargetChunk(absolutePath: string): { chunkFileName: string; moduleId: string; jsExt?: string } | null {
     // Detect JS extension from the resolved path (present when the source uses ESM-style specifiers)
     const jsExtMatch = absolutePath.match(/\.[cm]?js$/);
     const basePath = jsExtMatch ? absolutePath.slice(0, -jsExtMatch[0].length) : absolutePath;
@@ -117,13 +151,39 @@ export class ModuleDeclarationFixer {
 
     // Find which chunk contains this module
     for (const possiblePath of possiblePaths) {
-      const chunkFileName = this.moduleToChunk.get(normalizePath(possiblePath));
+      const moduleId = normalizePath(possiblePath);
+      const chunkFileName = this.moduleToChunk.get(moduleId);
       if (chunkFileName) {
-        return this.formatChunkReference(chunkFileName, jsExtMatch?.[0]);
+        return { chunkFileName, moduleId, jsExt: jsExtMatch?.[0] };
       }
     }
 
     return null;
+  }
+
+  /**
+   * Check that every augmented name is exported from the target chunk under its
+   * original name. Augmentation matches by exported name, so a name the chunk
+   * dropped, re-exported under an alias, or deconflicted (`Foo` → `Foo$1` when two
+   * modules in the chunk export a `Foo`) would merge into the wrong declaration.
+   */
+  private augmentationApplies(names: string[], moduleId: string, chunkFileName: string): boolean {
+    const chunkInfo = this.chunks[chunkFileName];
+    if (!chunkInfo) {
+      return true;
+    }
+
+    const targetModule = Object.entries(chunkInfo.modules).find(([id]) => normalizePath(id) === moduleId)?.[1];
+
+    return names.every((name) => {
+      if (!targetModule?.renderedExports.includes(name) || !chunkInfo.exports.includes(name)) {
+        return false;
+      }
+      // A `name$<digits>` sibling export means this name was deconflicted within the
+      // chunk, and there is no way to tell which module's declaration kept the name
+      const deconflicted = new RegExp(`^${name.replace(/\$/g, "\\$")}\\$\\d+$`);
+      return !chunkInfo.exports.some((exportName) => deconflicted.test(exportName));
+    });
   }
 
   /**

--- a/src/transform/ModuleDeclarationFixer.ts
+++ b/src/transform/ModuleDeclarationFixer.ts
@@ -70,7 +70,10 @@ export class ModuleDeclarationFixer {
   ) {
     this.code = code;
     this.sourcemap = sourcemap;
-    this.source = parse(chunk.fileName, code.toString());
+    // Parse the MagicString's original text, not toString(): the code may already
+    // carry TypeOnlyFixer edits, but overwrite() coordinates always refer to the
+    // original string, so node positions must come from that same text
+    this.source = parse(chunk.fileName, code.original);
     this.chunkFileName = chunk.fileName;
     this.moduleToChunk = moduleToChunk;
     this.chunks = chunks;

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -191,6 +191,7 @@ export const transform = (enableSourcemap: boolean) => {
         "magicCode" in typesFixed && typesFixed.magicCode ? typesFixed.magicCode : new MagicString(code),
         !!options.sourcemap,
         moduleToChunk,
+        meta.chunks,
         (message) => this.warn(message),
       );
 

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -352,6 +352,11 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
   // Resolve relative module declarations to absolute paths
   // This allows correct chunk resolution later even when files from different
   // directories are bundled together
+  //
+  // Deliberately limited to `./` / `../` specifiers: bare names (`declare module "vue"`)
+  // must stay untouched since consumers resolve them by package name, and tsconfig-paths
+  // aliases cannot be resolved lexically (see ModuleDeclarationFixer for the full
+  // mechanism and what alias support would require)
   const sourceDir = path.dirname(sourceFile.fileName);
   for (const node of sourceFile.statements) {
     if (

--- a/tests/testcases/declare-relative-module-index/consumer.ts
+++ b/tests/testcases/declare-relative-module-index/consumer.ts
@@ -1,0 +1,8 @@
+import { main } from "lib";
+
+const u = main();
+
+export const base: boolean = u.base;
+
+// the "./utils" augmentation is rewritten to the chunk and must apply
+export const augmented: number = u.augmented;

--- a/tests/testcases/declare-relative-module-index/expected-consumer.d.ts
+++ b/tests/testcases/declare-relative-module-index/expected-consumer.d.ts
@@ -1,0 +1,2 @@
+export declare const base: boolean;
+export declare const augmented: number;

--- a/tests/testcases/declare-relative-module-index/expected.d.ts
+++ b/tests/testcases/declare-relative-module-index/expected.d.ts
@@ -1,0 +1,11 @@
+interface U {
+  base: boolean;
+}
+declare function main(): U;
+declare module "./index" {
+  interface U {
+    augmented: number;
+  }
+}
+export { main };
+export type { U };

--- a/tests/testcases/declare-relative-module-index/index.d.ts
+++ b/tests/testcases/declare-relative-module-index/index.d.ts
@@ -1,0 +1,11 @@
+import type { U } from "./utils";
+
+export declare function main(): U;
+
+export type { U };
+
+declare module "./utils" {
+  interface U {
+    augmented: number;
+  }
+}

--- a/tests/testcases/declare-relative-module-index/meta.js
+++ b/tests/testcases/declare-relative-module-index/meta.js
@@ -1,0 +1,13 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  // `./utils` resolves to utils/index.d.ts, which is bundled into the entry
+  // chunk — the specifier must be rewritten to the chunk, with no warning
+  expectedWarnings: [],
+  rollupOptions: {
+    // alias the entry so the chunk is named `index.d.ts` (not `index.d.d.ts`)
+    // and the rewritten specifier reads `./index`
+    input: { index: "index.d.ts" },
+  },
+};

--- a/tests/testcases/declare-relative-module-index/meta.js
+++ b/tests/testcases/declare-relative-module-index/meta.js
@@ -10,4 +10,11 @@ export default {
     // and the rewritten specifier reads `./index`
     input: { index: "index.d.ts" },
   },
+  downstream: [
+    {
+      consumer: "consumer.ts",
+      expectedDts: "expected-consumer.d.ts",
+      compilerOptions: { module: "ESNext", moduleResolution: "Bundler" },
+    },
+  ],
 };

--- a/tests/testcases/declare-relative-module-index/utils/index.d.ts
+++ b/tests/testcases/declare-relative-module-index/utils/index.d.ts
@@ -1,0 +1,3 @@
+export interface U {
+  base: boolean;
+}

--- a/tests/testcases/declare-relative-module-renamed/consumer.ts
+++ b/tests/testcases/declare-relative-module-renamed/consumer.ts
@@ -1,0 +1,15 @@
+import type { FooA, FooB } from "lib/entry-a";
+import "lib/entry-b";
+
+declare const fooA: FooA;
+declare const fooB: FooB;
+
+export const a: string = fooA.a;
+export const b: string = fooB.b;
+
+// @ts-expect-error -- the kept "./foo-b" augmentation must not merge into the
+// conflicting Foo from foo-a (the collateral-merge hazard of a naive rewrite)
+export const collateral: number = fooA.extra;
+
+// @ts-expect-error -- the kept "./foo-b" augmentation stays dormant
+export const dormant: number = fooB.extra;

--- a/tests/testcases/declare-relative-module-renamed/entry-a.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/entry-a.d.ts
@@ -1,0 +1,2 @@
+export type { Foo as FooA } from "./foo-a";
+export type { Foo as FooB } from "./foo-b";

--- a/tests/testcases/declare-relative-module-renamed/entry-b.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/entry-b.d.ts
@@ -1,0 +1,8 @@
+export type { Foo as FooA } from "./foo-a";
+export type { Foo as FooB } from "./foo-b";
+
+declare module "./foo-b" {
+  interface Foo {
+    extra: number;
+  }
+}

--- a/tests/testcases/declare-relative-module-renamed/expected-consumer.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/expected-consumer.d.ts
@@ -1,0 +1,5 @@
+import "lib/entry-b";
+export declare const a: string;
+export declare const b: string;
+export declare const collateral: number;
+export declare const dormant: number;

--- a/tests/testcases/declare-relative-module-renamed/expected.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/expected.d.ts
@@ -1,0 +1,15 @@
+// entry-a.d.ts
+interface Foo$1 {
+  a: string;
+}
+interface Foo {
+  b: string;
+}
+export type { Foo$1 as FooA, Foo as FooB };
+// entry-b.d.ts
+export { FooA, FooB } from './entry-a.js';
+declare module "./foo-b" {
+  interface Foo {
+    extra: number;
+  }
+}

--- a/tests/testcases/declare-relative-module-renamed/foo-a.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/foo-a.d.ts
@@ -1,0 +1,3 @@
+export interface Foo {
+  a: string;
+}

--- a/tests/testcases/declare-relative-module-renamed/foo-b.d.ts
+++ b/tests/testcases/declare-relative-module-renamed/foo-b.d.ts
@@ -1,0 +1,3 @@
+export interface Foo {
+  b: string;
+}

--- a/tests/testcases/declare-relative-module-renamed/meta.js
+++ b/tests/testcases/declare-relative-module-renamed/meta.js
@@ -1,0 +1,31 @@
+// @ts-check
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  // foo-a and foo-b both export `Foo` and land in the same shared chunk, where
+  // Rollup renames one of them — retargeting the augmentation's specifier would
+  // merge `extra` into the wrong interface, so the original specifier is kept
+  expectedWarnings: [
+    `declare module "./foo-b" (${path.join(dir, "foo-b")}) augments names that the target chunk does not export unchanged, keeping the original specifier`,
+  ],
+  rollupOptions: {
+    input: {
+      "entry-a": "entry-a.d.ts",
+      "entry-b": "entry-b.d.ts",
+    },
+  },
+  downstream: [
+    {
+      consumer: "consumer.ts",
+      expectedDts: "expected-consumer.d.ts",
+    },
+  ],
+  // expected.d.ts encodes Rollup 4 chunk hosting and alias names; early Rollup 3
+  // produces an equivalent but differently-shaped chunk, failing only the snapshot
+  rollupVersion: "4.0.0",
+};

--- a/tests/testcases/declare-relative-module-tsx/Component.tsx
+++ b/tests/testcases/declare-relative-module-tsx/Component.tsx
@@ -1,0 +1,5 @@
+export interface Props {
+  title: string;
+}
+
+export declare function Component(props: Props): any;

--- a/tests/testcases/declare-relative-module-tsx/augment.d.ts
+++ b/tests/testcases/declare-relative-module-tsx/augment.d.ts
@@ -1,0 +1,7 @@
+declare module "./Component" {
+  interface Props {
+    extra?: boolean;
+  }
+}
+
+export {};

--- a/tests/testcases/declare-relative-module-tsx/expected.d.ts
+++ b/tests/testcases/declare-relative-module-tsx/expected.d.ts
@@ -1,0 +1,11 @@
+interface Props {
+    title: string;
+}
+declare function Component(props: Props): any;
+declare module "./index" {
+  interface Props {
+    extra?: boolean;
+  }
+}
+export { Component };
+export type { Props };

--- a/tests/testcases/declare-relative-module-tsx/index.ts
+++ b/tests/testcases/declare-relative-module-tsx/index.ts
@@ -1,0 +1,2 @@
+export { Component, type Props } from "./Component";
+import "./augment";

--- a/tests/testcases/declare-relative-module-tsx/meta.js
+++ b/tests/testcases/declare-relative-module-tsx/meta.js
@@ -1,0 +1,8 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  // `./Component` resolves to Component.tsx (Rollup module ids keep the
+  // original .tsx path) — the specifier must be rewritten, with no warning
+  expectedWarnings: [],
+};

--- a/tests/testcases/declare-relative-module-type-only/expected.d.ts
+++ b/tests/testcases/declare-relative-module-type-only/expected.d.ts
@@ -1,0 +1,17 @@
+interface Other {
+  base: string;
+}
+interface Foo {
+  someProp: boolean;
+}
+declare namespace ns {
+  export type { Foo };
+}
+declare function useOther(): Other;
+declare module "./index" {
+  interface Other {
+    extra: number;
+  }
+}
+export { ns, useOther };
+export type { Foo, Other };

--- a/tests/testcases/declare-relative-module-type-only/index.d.ts
+++ b/tests/testcases/declare-relative-module-type-only/index.d.ts
@@ -1,0 +1,19 @@
+import type { Other } from "./other";
+
+export interface Foo {
+  someProp: boolean;
+}
+
+export declare namespace ns {
+  export { Foo };
+}
+
+export declare function useOther(): Other;
+
+export type { Other };
+
+declare module "./other" {
+  interface Other {
+    extra: number;
+  }
+}

--- a/tests/testcases/declare-relative-module-type-only/meta.js
+++ b/tests/testcases/declare-relative-module-type-only/meta.js
@@ -1,0 +1,13 @@
+// @ts-check
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  // the type-only export fix inside the namespace shortens/lengthens the chunk
+  // text before the declare module statement — the specifier rewrite must not
+  // shift (TypeOnlyFixer edits and this rewrite share one MagicString, and all
+  // offsets must stay in the original string's coordinate space)
+  expectedWarnings: [],
+  rollupOptions: {
+    input: { index: "index.d.ts" },
+  },
+};

--- a/tests/testcases/declare-relative-module-type-only/other.d.ts
+++ b/tests/testcases/declare-relative-module-type-only/other.d.ts
@@ -1,0 +1,3 @@
+export interface Other {
+  base: string;
+}

--- a/tests/testcases/declare-relative-module-unresolved/consumer.ts
+++ b/tests/testcases/declare-relative-module-unresolved/consumer.ts
@@ -1,0 +1,9 @@
+import { getConfig } from "lib";
+
+const config = getConfig();
+
+export const base: string = config.base;
+
+// @ts-expect-error -- the unresolved "./orphan" augmentation must stay dormant
+// instead of merging into the chunk's own exported Config
+export const fromAugmentation: string = config.fromAugmentation;

--- a/tests/testcases/declare-relative-module-unresolved/expected-consumer.d.ts
+++ b/tests/testcases/declare-relative-module-unresolved/expected-consumer.d.ts
@@ -1,0 +1,2 @@
+export declare const base: string;
+export declare const fromAugmentation: string;

--- a/tests/testcases/declare-relative-module-unresolved/expected.d.ts
+++ b/tests/testcases/declare-relative-module-unresolved/expected.d.ts
@@ -1,0 +1,15 @@
+interface Config {
+  base: string;
+}
+declare function getConfig(): Config;
+declare module "./orphan" {
+  interface Config {
+    fromAugmentation: string;
+  }
+}
+declare module "./logo.svg" {
+  const url: string;
+  export { url };
+}
+export { getConfig };
+export type { Config };

--- a/tests/testcases/declare-relative-module-unresolved/index.d.ts
+++ b/tests/testcases/declare-relative-module-unresolved/index.d.ts
@@ -1,0 +1,16 @@
+export interface Config {
+  base: string;
+}
+
+export declare function getConfig(): Config;
+
+declare module "./orphan" {
+  interface Config {
+    fromAugmentation: string;
+  }
+}
+
+declare module "./logo.svg" {
+  const url: string;
+  export { url };
+}

--- a/tests/testcases/declare-relative-module-unresolved/meta.js
+++ b/tests/testcases/declare-relative-module-unresolved/meta.js
@@ -1,0 +1,27 @@
+// @ts-check
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+/** @param {string} specifier */
+function unresolvedWarning(specifier) {
+  return `declare module "${specifier}" (${path.join(dir, specifier)}) could not be resolved to any output chunk, keeping the original specifier`;
+}
+
+/** @type {import('../../testcases').Meta} */
+export default {
+  options: {},
+  // `./orphan` exists but is never imported and `./logo.svg` is not a module at
+  // all — neither maps to an output chunk, so the original specifiers must be
+  // preserved (the orphan augmentation names the chunk's own exported Config,
+  // which the old current-chunk fallback would have silently extended)
+  expectedWarnings: [unresolvedWarning("./orphan"), unresolvedWarning("./logo.svg")],
+  downstream: [
+    {
+      consumer: "consumer.ts",
+      expectedDts: "expected-consumer.d.ts",
+      compilerOptions: { skipLibCheck: false },
+    },
+  ],
+};

--- a/tests/testcases/declare-relative-module-unresolved/orphan.d.ts
+++ b/tests/testcases/declare-relative-module-unresolved/orphan.d.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  other: number;
+}


### PR DESCRIPTION
## Summary

Follow-up to #350 / #372, which deliberately kept scope to the most pressing use cases. This PR hardens the mechanism against the edge cases around that scope — six scenarios detailed in the linked issue — across four behavior commits plus one documentation commit, and adds tsc-level assertions that augmentations actually apply (or stay dormant) for a consumer of the bundled output.

Fixes #393

## Commits

Each commit is independently green and reviewable on its own.

### 1. `fix: keep original specifier for unresolvable relative declare module`

When the target cannot be matched to any output chunk, the specifier is now preserved (only the internal `dts-resolved:` marker is stripped) instead of being rewritten to the current chunk. A dangling relative augmentation in a module `.d.ts` is silently ignored by tsc, so the augmentation stays dormant — strictly safer than the previous behavior, where a same-named type exported by the current chunk silently gained the augmentation's members, and asset-style declarations turned into phantom exports on the chunk.

The miss warning now includes both the original specifier and the resolved absolute path, keeping same-named specifiers from different directories distinguishable:

```
declare module "./orphan" (/abs/src/orphan) could not be resolved to any output chunk, keeping the original specifier
```

### 2. `fix: resolve directory index and tsx targets of relative declare module`

The chunk lookup now probes `basePath + "/index"` variants and includes `.tsx`/`.jsx` in the extension list (Rollup module ids keep the original source path). Exact-path matches still win over index probing, matching Node resolution precedence. Targets like `./utils` → `utils/index.d.ts` and `./Component` → `Component.tsx` are rewritten to the correct chunk instead of warning and (pre-PR) being rewritten to the wrong one.

### 3. `fix: skip declare module rewrite when augmented names are renamed`

Module augmentation matches by the target module's exported names. The specifier is now rewritten only when the target chunk exports **every name declared in the augmentation body unchanged**: still rendered by the target module (`modules[id].renderedExports`), present in `chunk.exports`, and with no `name$<digits>` deconfliction sibling. Otherwise the original specifier is kept and a warning is emitted:

```
declare module "./foo-b" (/abs/src/foo-b) augments names that the target chunk does not export unchanged, keeping the original specifier
```

This prevents the silent wrong-type merge: previously, when two modules in one chunk both exported `Foo`, an augmentation intended for the renamed one merged its members into the *other* module's `Foo`.

### 4. `fix: prevent corrupted output when type-only fixes precede declare module`

`ModuleDeclarationFixer` now parses the MagicString's `original` text instead of `toString()`, so node positions and `overwrite()` coordinates share one coordinate space regardless of edits already recorded by `TypeOnlyFixer`. Previously, a length-changing type-only edit before a `declare module` statement shifted every later offset and garbled the emitted file (leaked marker, mangled specifier). Type-only edits never overlap a module declaration header, so both fixers safely share one MagicString and one composed sourcemap.

### 5. `docs: document declare module rewrite scope and alias limitation`

Class-level documentation of the marker → probe → rewrite/keep mechanism, and why the specifier filter is deliberately limited to `./`/`../`: bare package names must be preserved verbatim, and tsconfig-paths aliases cannot be resolved lexically. Includes the recipe for adding alias support later (paths-pattern-gated `ts.resolveModuleName` in preprocess, skipping `isExternalLibraryImport` results).

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Target not in any chunk (orphan, asset) | Rewritten to current chunk → wrong-module merge / phantom exports | Original specifier kept (dormant) + warning |
| Target is `dir/index.*` | Miss → rewritten to current chunk | Rewritten to the correct chunk |
| Target is a `.tsx`/`.jsx` module | Miss → rewritten to current chunk | Rewritten to the correct chunk |
| Augmented name renamed/aliased/dropped by the chunk | Rewritten → silent wrong-type merge or dead augmentation | Original specifier kept (dormant) + warning |
| Type-only fix before `declare module` | Corrupted output text | Clean output |

## Tests

Five new testcases (`declare-relative-module-{unresolved,index,tsx,renamed,type-only}`), including downstream consumers that compile against the bundle packaged as a node module:

- `-index` proves a rewritten augmentation **applies**: the consumer compiles `u.augmented` (moduleResolution `Bundler`).
- `-unresolved` and `-renamed` prove kept augmentations stay **dormant** with no collateral merge, via `@ts-expect-error` assertions that fail (TS2578) if the augmentation ever starts applying — a direct regression trip-wire for the pre-PR behavior.
- `-type-only` pins the coordinate-space fix with a length-changing type-only edit before the declare module; reverting the fix garbles the snapshot.

Full suite verified on current deps and at the minimum supported peers (`typescript@4.5` + `rollup@3.0`, matching the CI compat step). Four of the five testcases run at the minimum peers too; `-renamed` is gated `rollupVersion: "4.0.0"` because its snapshot encodes Rollup 4 chunk hosting and alias names — early Rollup 3 emits an equivalent but differently-shaped chunk (the fixer behavior is identical there; verified via its downstream consumer, which passes on 3.x).

## Known accepted residuals (documented in code/tests)

- A kept specifier re-resolves relative to the emitted chunk, so dormancy is not *guaranteed* if a file coincidentally exists at that path next to the chunk — still strictly narrower risk than the previous always-rewrite.
- The rename guard works from chunk metadata; a deconflicted name whose rename is unexported while another module's same-named export kept the original name is invisible to it. Requires internal-only usage of the renamed type; strictly rarer than the pre-guard behavior.
- tsconfig-paths aliases remain unsupported (documented limitation with an implementation sketch in the code).
