### PR TITLE
fix: restore rollup ^3 peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "@babel/code-frame": "^7.29.7"
       },
       "peerDependencies": {
-        "rollup": "^3.29.4 || ^4",
-        "typescript": "^4.5 || ^5.0 || ^6.0"
+        "rollup": "^3 || ^4",
+        "typescript": "^4.5 || ^5 || ^6"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "rollup": "^3.29.4 || ^4",
-    "typescript": "^4.5 || ^5.0 || ^6.0"
+    "rollup": "^3 || ^4",
+    "typescript": "^4.5 || ^5 || ^6"
   },
   "optionalDependencies": {
     "@babel/code-frame": "^7.29.7"

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,25 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "schedule:weekly",
     "group:allNonMajor",
     ":automergeMinor",
-    ":automergeBranchPush",
+    ":automergeBranch",
     ":automergeRequireAllStatusChecks"
   ],
   "rangeStrategy": "bump",
   "packageRules": [
     {
-      "description": "Ignore node and peerDependencies",
-      "matchPackageNames": ["node"],
+      "description": "Ignore Node engine updates",
       "matchManagers": ["npm"],
-      "matchDepTypes": ["engines", "peerDependencies"],
+      "matchDepTypes": ["engines"],
+      "matchDepNames": ["node"],
+      "enabled": false
+    },
+    {
+      "description": "Ignore peerDependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["peerDependencies"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Summary

Lowers the rollup peer dependency back to `^3 || ^4` and fixes the Renovate rule that kept bumping it against your intent.

## Why the peer range was `^3.29.4` in the first place

You intentionally set the peer dependency range to `^3.0.0` at least twice (e.g. ba136fa), but Renovate kept bumping it back up — the last bump to `^3.29.4` landed in baad4ed. The `renovate.json` rule meant to prevent this ("Ignore node and peerDependencies") never worked: all `match*` conditions within a packageRule are ANDed together, so `matchPackageNames: ["node"]` limited the entire rule to the `node` package, and `rollup` in `peerDependencies` was never matched.

## Changes

- **`renovate.json`**: split the broken rule into two — one ignoring Node engine updates, one ignoring all `peerDependencies` updates. Used `matchDepNames`, which matches the literal name in `package.json` (unlike `matchPackageNames`, which matches the derived lookup name that Renovate remaps for some packages). Also applied the migrations flagged by `renovate-config-validator`: `config:base` → `config:recommended` and `:automergeBranchPush` → `:automergeBranch` (pure renames, no behavior change). The config now validates with no warnings.
- **`package.json`**: peer dependency lowered to `"rollup": "^3 || ^4"`, matching the original intent. This range is already CI-tested (the workflow runs `rollup@3.0`). Also simplified the TypeScript range notation (`^4.5 || ^5 || ^6` — same semantics).

## Notes

Weekly download data suggests the 3.0.0 – 3.29.3 range is a small slice of rollup usage (~0.5%), so this is mostly about correctness of intent rather than unlocking a large user base — but since CI already covers rollup 3.0, there's no cost to supporting it.