### PR TITLE
feat: support TypeScript 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ plugins: [dts({
 })]
 ```
 
+## TypeScript 7 support
+
+TypeScript 7.0 (the native compiler) does not ship a compiler API, which this
+plugin relies on. When your project uses `typescript@7`, additionally install
+the official compatibility package that provides the TypeScript 6 API:
+
+    $ npm install --save-dev @typescript/typescript6
+
+The plugin uses the API from your `typescript` package when it provides one
+(TypeScript 4.5 – 6.x), and automatically falls back to
+`@typescript/typescript6` otherwise. Declaration files are parsed and emitted
+with the TypeScript 6 language behavior in that case, which is identical for
+declaration output. Once TypeScript 7.1+ ships its new compiler API, a future
+release will support it directly.
+
+Note that this plugin's public types reference the `typescript` package (e.g.,
+`ts.CompilerOptions`), which `typescript@7` does not currently provide. If you
+type-check a file that imports `rollup-plugin-dts` (such as `rollup.config.ts`)
+with TypeScript 7, enable [`skipLibCheck`](https://www.typescriptlang.org/tsconfig/#skipLibCheck)
+to avoid a spurious error inside the plugin's declaration file.
+
 ## Maintenance Mode
 
 This project is in _maintenance mode_. That means there will be no more active feature development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,10 @@
         "@types/estree": "1.0.9",
         "@types/node": "^25.9.5",
         "@types/react": "^19.2.17",
+        "@typescript/native": "npm:typescript@^7.0.2",
         "c8": "^12.0.0",
         "rollup": "4.62.2",
-        "typescript": "6.0.3"
+        "typescript": "npm:@typescript/typescript6@^6.0.2"
       },
       "engines": {
         "node": ">=20"
@@ -37,8 +38,14 @@
         "@babel/code-frame": "^7.29.7"
       },
       "peerDependencies": {
+        "@typescript/typescript6": "^6",
         "rollup": "^3 || ^4",
-        "typescript": "^4.5 || ^5 || ^6"
+        "typescript": "^4.5 || ^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@typescript/typescript6": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -583,6 +590,397 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -1198,17 +1596,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -56,13 +56,20 @@
     "@types/estree": "1.0.9",
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.17",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "c8": "^12.0.0",
     "rollup": "4.62.2",
-    "typescript": "6.0.3"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "peerDependencies": {
+    "@typescript/typescript6": "^6",
     "rollup": "^3 || ^4",
-    "typescript": "^4.5 || ^5 || ^6"
+    "typescript": "^4.5 || ^5 || ^6 || ^7"
+  },
+  "peerDependenciesMeta": {
+    "@typescript/typescript6": {
+      "optional": true
+    }
   },
   "optionalDependencies": {
     "@babel/code-frame": "^7.29.7"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,9 +1,25 @@
 import * as fs from "node:fs";
-import type { RollupWatchOptions } from "rollup";
+import * as path from "node:path";
+import type { Plugin, RollupWatchOptions } from "rollup";
 import dts from "./src/index.js";
 
 const pkg = JSON.parse(fs.readFileSync("./package.json", { encoding: "utf-8" }));
-const external = ["node:module", "node:path", "node:fs", "node:fs/promises", "typescript", "rollup", "@babel/code-frame", "magic-string", "@jridgewell/remapping", "@jridgewell/sourcemap-codec", "convert-source-map"];
+const external = ["node:module", "node:path", "node:fs", "node:fs/promises", "rollup", "@babel/code-frame", "magic-string", "@jridgewell/remapping", "@jridgewell/sourcemap-codec", "convert-source-map"];
+
+// Substitute src/typescript-shim.mjs for `import ts from "typescript"` in the
+// bundled output. The shim loads the compiler API from the user's `typescript`
+// package, falling back to `@typescript/typescript6` for TypeScript 7, which
+// does not ship a compiler API. Source files keep importing "typescript"
+// directly so they get its types; only the published bundle is redirected.
+const typescriptShim: Plugin = {
+  name: "typescript-shim",
+  resolveId(source) {
+    if (source === "typescript") {
+      return path.resolve("./src/typescript-shim.mjs");
+    }
+    return null;
+  },
+};
 
 const config: Array<RollupWatchOptions> = [
   {
@@ -13,6 +29,7 @@ const config: Array<RollupWatchOptions> = [
       { file: pkg.exports.require, format: "commonjs", exports: "named" },
     ],
     external,
+    plugins: [typescriptShim],
   },
   {
     input: "./.build/src/index.d.ts",

--- a/src/typescript-shim.mjs
+++ b/src/typescript-shim.mjs
@@ -1,0 +1,44 @@
+// This module replaces `import ts from "typescript"` in the bundled output
+// (see the typescript-shim plugin in rollup.config.ts).
+//
+// TypeScript 7 (the native compiler) does not ship a compiler API — it only
+// exports `version`. Until the new API arrives in TypeScript 7.1+, users on
+// typescript@7 need the `@typescript/typescript6` compatibility package,
+// which provides the TypeScript 6.0 API.
+//
+// `require` is used instead of static imports so that a missing or API-less
+// `typescript` package can be detected and recovered from at runtime.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+function loadTypeScript() {
+  let ts;
+  try {
+    ts = require("typescript");
+  } catch {
+    // not installed, or an ESM-only entry point that this Node version cannot `require`
+  }
+  if (ts && typeof ts.createProgram === "function") {
+    return ts;
+  }
+  try {
+    return require("@typescript/typescript6");
+  } catch {
+    if (ts) {
+      throw new Error(
+        `rollup-plugin-dts requires the TypeScript compiler API. The installed typescript@${ts.version} does not provide it, ` +
+          "and the `@typescript/typescript6` fallback is not installed.\n" +
+          "TypeScript 7 does not ship a compiler API, so please additionally install the compatibility package:\n" +
+          "  npm install -D @typescript/typescript6",
+      );
+    }
+    throw new Error(
+      "rollup-plugin-dts requires the TypeScript compiler API, but the `typescript` package could not be loaded.\n" +
+        "Please install typescript 4.5 - 6.x, or typescript 7 together with the `@typescript/typescript6` compatibility package:\n" +
+        "  npm install -D typescript",
+    );
+  }
+}
+
+export default loadTypeScript();

--- a/tests/downstream-helpers.ts
+++ b/tests/downstream-helpers.ts
@@ -109,7 +109,9 @@ export async function assertDownstream(
   downstream: DownstreamCase[],
   bless: boolean,
 ) {
-  const tscBin = path.resolve("node_modules/typescript/bin/tsc");
+  // Type-check the bundled output with the native TypeScript 7 compiler
+  // ("typescript" resolves to @typescript/typescript6, whose bin is `tsc6`).
+  const tscBin = path.resolve("node_modules/@typescript/native/bin/tsc");
 
   for (const testCase of downstream) {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rollup-plugin-dts-downstream-"));

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,6 @@
 import downstream from "./downstream.js";
 import preprocess from "./preprocess.js";
+import shim from "./shim.js";
 import sourcemap from "./sourcemap.js";
 import testcases from "./testcases.js";
 import { Harness } from "./utils.js";
@@ -11,6 +12,7 @@ async function main() {
 
   downstream(harness);
   preprocess(harness);
+  shim(harness);
   sourcemap(harness);
   testcases(harness);
 

--- a/tests/shim.ts
+++ b/tests/shim.ts
@@ -31,6 +31,15 @@ if (typeof dts.default !== "function") {
 }
 `;
 
+const CONSUMER_CONFIG = `import dts from "rollup-plugin-dts";
+
+export default {
+  input: "src/index.d.ts",
+  output: { file: "out/index.d.ts", format: "es" },
+  plugins: [dts()],
+};
+`;
+
 // use junctions so directory links work on Windows without elevated privileges
 async function link(target: string, linkPath: string) {
   await fs.mkdir(path.dirname(linkPath), { recursive: true });
@@ -46,8 +55,12 @@ async function createFixture(tempRoot: string) {
   await fs.writeFile(path.join(tempRoot, "src", "index.d.ts"), SAMPLE_DTS);
   await fs.writeFile(path.join(tempRoot, "consumer.mjs"), CONSUMER_MJS);
   await fs.writeFile(path.join(tempRoot, "consumer.cjs"), CONSUMER_CJS);
+  await fs.writeFile(path.join(tempRoot, "rollup.config.mjs"), CONSUMER_CONFIG);
 
   await fs.mkdir(pluginDir, { recursive: true });
+  // dist must be copied, not linked: Node resolves modules to their real path,
+  // so a linked dist would make the shim resolve `typescript` from this repo's
+  // node_modules and defeat the fixture isolation
   await fs.cp(path.resolve("dist"), path.join(pluginDir, "dist"), { recursive: true });
   await fs.writeFile(
     path.join(pluginDir, "package.json"),
@@ -93,6 +106,14 @@ export default (t: Harness) => {
       assert.ok(fallback.stdout.includes("interface Foo"), fallback.stdout);
       const fallbackCjs = runNode(tempRoot, ["consumer.cjs"]);
       assert.strictEqual(fallbackCjs.status, 0, fallbackCjs.stderr);
+
+      // the rollup cli loads the config file through its own bundling step,
+      // so also cover that path importing the plugin
+      const rollupBin = path.join(tempRoot, "node_modules", "rollup", "dist", "bin", "rollup");
+      const cli = runNode(tempRoot, [rollupBin, "--config", "--silent"]);
+      assert.strictEqual(cli.status, 0, `${cli.stdout}${cli.stderr}`);
+      const cliOutput = await fs.readFile(path.join(tempRoot, "out", "index.d.ts"), "utf-8");
+      assert.ok(cliOutput.includes("interface Foo"), cliOutput);
 
       // typescript@7 without the fallback: guided error
       await fs.rm(ts6Link, { recursive: true, force: true });

--- a/tests/shim.ts
+++ b/tests/shim.ts
@@ -1,0 +1,112 @@
+import * as assert from "assert";
+import { spawnSync } from "child_process";
+import fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { Harness } from "./utils.js";
+
+// The published bundles load the TypeScript compiler API through
+// src/typescript-shim.mjs, which the other tests never execute (they import
+// the plugin from source, where "typescript" resolves directly). Smoke-test
+// the shim against the actual dist bundles in a synthetic node_modules with
+// different `typescript` installations.
+
+const SAMPLE_DTS = `export interface Foo {
+  bar: number;
+}
+export type Bar = Foo["bar"];
+`;
+
+const CONSUMER_MJS = `import { rollup } from "rollup";
+import dts from "rollup-plugin-dts";
+
+const bundle = await rollup({ input: "src/index.d.ts", plugins: [dts()], onwarn() {} });
+const { output } = await bundle.generate({ format: "es" });
+process.stdout.write(output[0].code);
+`;
+
+const CONSUMER_CJS = `const dts = require("rollup-plugin-dts");
+if (typeof dts.default !== "function") {
+  throw new Error("unexpected default export: " + typeof dts.default);
+}
+`;
+
+// use junctions so directory links work on Windows without elevated privileges
+async function link(target: string, linkPath: string) {
+  await fs.mkdir(path.dirname(linkPath), { recursive: true });
+  await fs.symlink(target, linkPath, "junction");
+}
+
+async function createFixture(tempRoot: string) {
+  const pkg = JSON.parse(await fs.readFile(path.resolve("package.json"), "utf-8"));
+  const pluginDir = path.join(tempRoot, "node_modules", "rollup-plugin-dts");
+
+  await fs.mkdir(path.join(tempRoot, "src"), { recursive: true });
+  await fs.writeFile(path.join(tempRoot, "package.json"), '{ "type": "module" }\n');
+  await fs.writeFile(path.join(tempRoot, "src", "index.d.ts"), SAMPLE_DTS);
+  await fs.writeFile(path.join(tempRoot, "consumer.mjs"), CONSUMER_MJS);
+  await fs.writeFile(path.join(tempRoot, "consumer.cjs"), CONSUMER_CJS);
+
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.cp(path.resolve("dist"), path.join(pluginDir, "dist"), { recursive: true });
+  await fs.writeFile(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({ name: "rollup-plugin-dts", type: pkg.type, main: pkg.main, exports: pkg.exports }, null, 2),
+  );
+
+  const runtimeDeps = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.optionalDependencies ?? {}), "rollup"];
+  for (const dep of runtimeDeps) {
+    await link(path.resolve("node_modules", dep), path.join(tempRoot, "node_modules", dep));
+  }
+}
+
+function runNode(cwd: string, args: Array<string>) {
+  return spawnSync(process.execPath, args, { cwd, encoding: "utf8" });
+}
+
+export default (t: Harness) => {
+  t.test("typescript-shim", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rollup-plugin-dts-shim-"));
+    const tsLink = path.join(tempRoot, "node_modules", "typescript");
+    const ts6Link = path.join(tempRoot, "node_modules", "@typescript", "typescript6");
+    // in this repo, node_modules/typescript is the aliased @typescript/typescript6
+    // install (which provides the compiler API), and node_modules/@typescript/native
+    // is typescript@7 (which does not)
+    const tsWithApi = path.resolve("node_modules/typescript");
+    const ts7 = path.resolve("node_modules/@typescript/native");
+
+    try {
+      await createFixture(tempRoot);
+
+      // typescript 4.5 - 6.x: the API comes straight from the user's package
+      await link(tsWithApi, tsLink);
+      const primary = runNode(tempRoot, ["consumer.mjs"]);
+      assert.strictEqual(primary.status, 0, primary.stderr);
+      assert.ok(primary.stdout.includes("interface Foo"), primary.stdout);
+
+      // typescript@7 with the @typescript/typescript6 fallback installed
+      await fs.rm(tsLink, { recursive: true, force: true });
+      await link(ts7, tsLink);
+      await link(tsWithApi, ts6Link);
+      const fallback = runNode(tempRoot, ["consumer.mjs"]);
+      assert.strictEqual(fallback.status, 0, fallback.stderr);
+      assert.ok(fallback.stdout.includes("interface Foo"), fallback.stdout);
+      const fallbackCjs = runNode(tempRoot, ["consumer.cjs"]);
+      assert.strictEqual(fallbackCjs.status, 0, fallbackCjs.stderr);
+
+      // typescript@7 without the fallback: guided error
+      await fs.rm(ts6Link, { recursive: true, force: true });
+      const missingFallback = runNode(tempRoot, ["consumer.mjs"]);
+      assert.notStrictEqual(missingFallback.status, 0, "expected the consumer to fail without @typescript/typescript6");
+      assert.ok(missingFallback.stderr.includes("npm install -D @typescript/typescript6"), missingFallback.stderr);
+
+      // no typescript at all: guided error
+      await fs.rm(tsLink, { recursive: true, force: true });
+      const missingTypeScript = runNode(tempRoot, ["consumer.mjs"]);
+      assert.notStrictEqual(missingTypeScript.status, 0, "expected the consumer to fail without typescript");
+      assert.ok(missingTypeScript.stderr.includes("npm install -D typescript"), missingTypeScript.stderr);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+};


### PR DESCRIPTION
TypeScript 7.0 does not ship the JS compiler API, so the published bundle now loads the API at runtime: from the user's `typescript` package when it provides one (TypeScript 4.5 - 6.x), with a fallback to the official `@typescript/typescript6` compatibility package under `typescript@7`, and a guided error when neither is available. Most of the diff is the lockfile.

- `src/typescript-shim.mjs` is the runtime loader (~40 lines). Fully synchronous via `createRequire`, resolved once at module load, just like the previous static import. A small `resolveId` hook in `rollup.config.ts` substitutes it for `import ts from "typescript"` at bundle time, so source files are untouched and keep the real `typescript` import for its types; only the published bundle is redirected.
- `package.json` allows `typescript@7` in peer dependencies and adds `@typescript/typescript6` as an optional peer. Nothing changes for TS <= 6 users; declaring the optional peer also makes the fallback resolvable under pnpm's strict layout and Yarn PnP.
- `tests/shim.ts` is a new smoke test that runs the published bundles (both entry points) in a synthetic `node_modules`, covering all shim paths: TS with the API, TS 7 with the fallback, TS 7 without it, and no TS at all. The other tests import the plugin from source, so this is the only place the shim is actually executed.
- `README.md` documents the setup for `typescript@7` users, including a note that they need `skipLibCheck` when type-checking code that imports the plugin (the public types reference `ts.CompilerOptions`, which `typescript@7` does not provide).
- The repo itself now builds with the native TypeScript 7 compiler (via the `@typescript/native` npm alias), and the downstream tests type-check bundled output with it, while source type-checking stays on the TS 6 API types via the `typescript@npm:@typescript/typescript6` alias.

Verified beyond CI:

- `npm install` peer resolution against real `typescript@7.0.2`, and against the alias setup recommended in the TS release notes
- end-to-end `.d.ts` bundle through the fallback path, using the packed tarball in a fresh project

TypeScript 7.0 introduces no new syntax, so parsing and emitting declarations with the 6.0 API produces identical output. Once the new API ships in TS 7.1+, the shim can be deleted wholesale as part of that migration.

Closes #395 