### PR TITLE
chore: drop unnecessary rollup SourceMap cast in transform hook

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { OutputBundle, Plugin, SourceMap } from "rollup";
+import type { OutputBundle, Plugin } from "rollup";
 import remapping from "@jridgewell/remapping";
 import type { RawSourceMap } from "@jridgewell/remapping";
 import { NamespaceFixer } from "./NamespaceFixer.js";
@@ -133,7 +133,7 @@ export const transform = (enableSourcemap: boolean) => {
         });
       }
 
-      return { code, ast: converted.ast as any, map: map as unknown as SourceMap };
+      return { code, ast: converted.ast as any, map };
     },
 
     renderChunk(inputCode, chunk, options, meta) {


### PR DESCRIPTION
Rollup 4.62.4 widened `SourceMap.sourcesContent` from `string[]` to `(string | null)[]`. That type is no longer assignable to `ExistingRawSourceMap` / `SourceMapInput`, which is what the `transform` hook's `map` field expects — so `tsc` fails the build as soon as rollup is bumped:

```
src/transform/index.ts:86:5 - error TS2322: Type '(this: TransformPluginContext, code: string, ...
...
Types of property 'sourcesContent' are incompatible.
Type '(string | null)[] | undefined' is not assignable to type 'string[] | undefined'.
```

The cast was never needed: magic-string's own `SourceMap` (`sourcesContent?: string[]`) already satisfies `SourceMapInput` structurally, so the map can be returned as-is.

No runtime behavior changes — this is types only.

Unblocks #400 and future Renovate updates.

## Verification

- `npm run build` — clean
- `npm test` — full suite passes